### PR TITLE
Proposed fix for #974: Cause Mission 21 to fail if the Prototype is destroyed

### DIFF
--- a/src/hu/openig/scripting/missions/Mission21.java
+++ b/src/hu/openig/scripting/missions/Mission21.java
@@ -218,7 +218,7 @@ public class Mission21 extends Mission {
 		addInventory(f, "Fighter2", 4);
 		
 		InventoryItem ii = f.getInventoryItem(d);
-		
+
 		setSlot(ii, "laser1", "Laser1", 6);
 		setSlot(ii, "laser2", "Laser2", 4);
 		setSlot(ii, "shield", "Shield1", 1);
@@ -267,9 +267,11 @@ public class Mission21 extends Mission {
 	boolean concludeBattle(BattleInfo battle) {
 		boolean result = false;
 		clearMission("Mission-21-Timeout");
-		Fleet carrier = findTaggedFleet(ALLY, player);
 
-		if (carrier != null) {
+		Fleet prototypeFleet = findTaggedFleet(ALLY, player);
+		// If the prototype fleet still exists and contains a Destroyer2, the player
+		// has successfully defended the prototype.
+		if (prototypeFleet != null && !prototypeFleet.inventory.findByType("Destroyer2").isEmpty()) {
 			setObjectiveState("Mission-21", ObjectiveState.SUCCESS);
 			addTimeout("Mission-21-Hide", 13000);
 			addTimeout("Mission-21-Thanks", 5000);


### PR DESCRIPTION
Check to see if the Prototype is among the space losses rather than checking to see if the Prototype fleet still exists, since the Prototype fleet could still have fighters that survived the battle and would cause the fleet to still exist even if the Prototype was destroyed.

Proposed fix for #974 
@akarnokd Does this use of `battle.spaceLosses` make sense to you? It seems appropriate, but you would know if there's a better way to do this check.

