### PR TITLE
Tax level to morale

### DIFF
--- a/src/hu/openig/mechanics/Simulator.java
+++ b/src/hu/openig/mechanics/Simulator.java
@@ -33,7 +33,6 @@ import hu.openig.model.ResearchMainCategory;
 import hu.openig.model.ResearchState;
 import hu.openig.model.ResearchSubCategory;
 import hu.openig.model.ResearchType;
-import hu.openig.model.TaxLevel;
 import hu.openig.model.Trait;
 import hu.openig.model.TraitKind;
 import hu.openig.model.World;
@@ -420,22 +419,7 @@ public final class Simulator {
 		if (world.config.continuousMoney || dayChange) {	
 			// FIXME morale computation
 			double newMorale = 50 + moraleBoost;
-			if (planet.tax == TaxLevel.NONE) {
-				newMorale += 5;
-			} else
-			if (planet.tax.ordinal() <= TaxLevel.MODERATE.ordinal()) {
-				if (!planet.owner.race.equals(planet.race)) {
-					newMorale -= planet.tax.percent / 4f;
-				} else {
-					newMorale -= planet.tax.percent / 6f;
-				}
-			} else {
-				if (!planet.owner.race.equals(planet.race)) {
-					newMorale -= planet.tax.percent / 2.5f;
-				} else {
-					newMorale -= planet.tax.percent / 3f;
-				}
-			}
+			newMorale += planet.tax.getMoraleChange(planet.owner.race.equals(planet.race));
 			if (ps.houseAvailable < planet.population()) {
 				newMorale += (ps.houseAvailable - planet.population()) * 75f / planet.population();
 			} else {

--- a/src/hu/openig/model/TaxLevel.java
+++ b/src/hu/openig/model/TaxLevel.java
@@ -34,12 +34,61 @@ public enum TaxLevel {
 	/** Slavery. */
 	SLAVERY
 	;
-	/** The taxation percent. */
-	public final int percent;
-	/**
-	 * Constructor.
-	 */
-	TaxLevel() {
-		this.percent = 100 * ordinal() / 9;
-	}
+	
+        private static final float NO_TAX_MORALE = 5f;
+        private static final int MAX_LEVEL = 9;
+        private static final int MAX_TAX = 100;
+        private static final float MAX_TAX_MORALE_SAME = -100f / 3f;
+        private static final float MAX_TAX_MORALE_OTHER = -40f;
+        private static final int BASE_LEVEL = 3;
+        private static final int BASE_TAX = MAX_TAX * BASE_LEVEL / MAX_LEVEL;
+        private static final float BASE_TAX_MORALE_SAME = -5.5f;
+        private static final float BASE_TAX_MORALE_OTHER = -8.25f;
+
+        /**
+         * The taxation percent.
+         */
+        public final int percent;
+        /**
+         * Same race morale change.
+         */
+        private final float sameMorale;
+        /**
+         * Different race morale change.
+         */
+        private final float otherMorale;
+
+        /**
+         * Constructor.
+         */
+        TaxLevel() {
+                this.percent = MAX_TAX * ordinal() / MAX_LEVEL;
+
+                if (this.percent == 0) {
+                        this.sameMorale = NO_TAX_MORALE;
+                        this.otherMorale = NO_TAX_MORALE;
+                } else if (this.percent <= BASE_TAX) {
+                        this.sameMorale = BASE_TAX_MORALE_SAME * this.percent / BASE_TAX;
+                        this.otherMorale = BASE_TAX_MORALE_OTHER * this.percent / BASE_TAX;
+                } else {
+                        this.sameMorale = BASE_TAX_MORALE_SAME
+                                + (MAX_TAX_MORALE_SAME - BASE_TAX_MORALE_SAME)
+                                * (this.percent - BASE_TAX) / (MAX_TAX - BASE_TAX);
+                        this.otherMorale = BASE_TAX_MORALE_OTHER
+                                + (MAX_TAX_MORALE_OTHER - BASE_TAX_MORALE_OTHER)
+                                * (this.percent - BASE_TAX) / (MAX_TAX - BASE_TAX);
+                }
+        }
+
+        /**
+         * @param sameRace If planet race is Empire's main race.
+         * @return Morale change for this tax level and selected race.
+         */
+        public float getMoraleChange(boolean sameRace) {
+                if (sameRace) {
+                        return sameMorale;
+                } else {
+                        return otherMorale;
+                }
+        }
 }


### PR DESCRIPTION
Fixed tax to morale scaling between "Moderate" and "Above Moderate" tax level. 
Used to be: 
Low -> Moderate = **-1.83** morale
Moderate -> Above Moderate = **-10.87** morale
Above Moderat -> High = **-3.66** morale

old scaling (see jump between 33 and 44)
```
	same	other
0	5.00	5.00
11	-1.83	-2.75
22	-3.67	-5.50
33	-5.50	-8.25
44	-14.67	-17.60
55	-18.33	-22.00
66	-22.00	-26.40
77	-25.67	-30.80
88	-29.33	-35.20
100	-33.33	-40.00
```

new scaling (same tax at 33 and 100 but more consistent scaling)
```
	same	other
0	5.00	5.00
11	-1.83	-2.75
22	-3.67	-5.50
33	-5.50	-8.25
44	-10.07	-13.46
55	-14.64	-18.68
66	-19.21	-23.89
77	-23.78	-29.10
88	-28.35	-34.31
100	-33.33	-40.00
```