### PR TITLE
Water vaporator for cratered planet

### DIFF
--- a/data/generic/campaign/main/buildings.xml
+++ b/data/generic/campaign/main/buildings.xml
@@ -258,7 +258,7 @@
       <tech id='dribs' height='5' width='5' image='colony/buildings/human/water_vaporator' skirmish-only='true'/>
       <tech id='dargslan' height='5' width='5' image='colony/buildings/human/water_vaporator' skirmish-only='true'/>
     </graphics>
-    <build limit='1' kind='House' cost='45000' except='earth,frozen,liquid,rocky,cratered,neptoplasm'/>
+    <build limit='1' kind='House' cost='45000' except='earth,frozen,liquid,rocky,neptoplasm'/>
     <operation>
       <resource type='population-growth' display='true'>100</resource>
       <resource type='morale'>10</resource>

--- a/dlc/gump891202-racemod-0.1/generic/skirmish/racemod-0.1/buildings.xml
+++ b/dlc/gump891202-racemod-0.1/generic/skirmish/racemod-0.1/buildings.xml
@@ -223,7 +223,7 @@
     <graphics>
       <tech id='human' height='5' width='5' image='colony/buildings/human/water_vaporator'/>
     </graphics>
-    <build limit='1' kind='House' cost='45000' except='earth,frozen,liquid,rocky,cratered,neptoplasm'/>
+    <build limit='1' kind='House' cost='45000' except='earth,frozen,liquid,rocky,neptoplasm'/>
     <operation>
       <resource type='population-growth' display='true'>100</resource>
       <resource type='morale'>10</resource>


### PR DESCRIPTION
According to guide at http://www.ign.com/faqs/2004/imperium-galactica-walkthrough-393220. Water Vaporator building works at both **Desert** and **Cratered** planet type.

This patch enable Water Vaporator building to be build at **Cratered** planet.