### PR TITLE
[wip] Remove unfinished buildings when a planet is captured.

### DIFF
--- a/src/hu/openig/model/Planet.java
+++ b/src/hu/openig/model/Planet.java
@@ -710,6 +710,10 @@ public class Planet implements Named, Owned, HasInventory, HasPosition {
 			lastOwner.statistics.planetsLostAlien.value++;
 		}
 		lastOwner.statistics.planetsLost.value++;
+		
+		// unfinished buildings need to be removed from the surface
+		// before granting technology for captured buildings.
+		removeUnfinishedBuildings();
 		for (Building b : surface.buildings.iterable()) {
 			if (b.type.research != null) {
 				newOwner.setAvailable(b.type.research);
@@ -732,6 +736,20 @@ public class Planet implements Named, Owned, HasInventory, HasPosition {
 		newOwner.ai.onPlanetConquered(this, lastOwner);
 		world.scripting.onConquered(this, lastOwner);
 	}
+	
+	/**
+	 * Remove unfinished buildings from the planet's
+	 * surface and then rebuild the roads.
+	 */
+	public void removeUnfinishedBuildings() {
+		for (Building b : this.surface.buildings.list()) {
+			if (!b.isComplete()) {
+				this.surface.removeBuilding(b);
+			}
+		}
+		rebuildRoads();
+	}
+	
 	/**
 	 * Sell remaining units of the last owner at a 25% price.
 	 * @param lastOwner the last owner

--- a/src/hu/openig/screen/items/PlanetScreen.java
+++ b/src/hu/openig/screen/items/PlanetScreen.java
@@ -4533,15 +4533,6 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
 			planet().takeover(winner);
 
 			BattleSimulator.applyPlanetConquered(planet(), BattleSimulator.PLANET_CONQUER_LOSS);
-
-			// remove unfinished buildings
-			for (Building b : planet().surface.buildings.list()) {
-				if (!b.isComplete()) {
-					destroyBuilding(b);
-				}
-			}
-			planet().rebuildRoads();
-			
 		} else {
 			BattleSimulator.applyPlanetDefended(planet(), BattleSimulator.PLANET_DEFENSE_LOSS);
 		}


### PR DESCRIPTION
This is a stab at fixing the problem described in https://github.com/akarnokd/open-ig/issues/996. 

Currently incomplete buildings aren't cleaned up when an autobattle takes place. This change makes cleaning up unfinished buildings part of the planet takeover step so that it's always performed regardless of how the planet is captured (surrender, autobattle, normal ground combat, etc). I believe that this removal of incomplete buildings is consistent with the original game. (much to the frustration of my 10-year-old self attempting to capture half-built planetary defense guns)

A side effect of moving unfinished building cleanup to the takeover step is that the unfinished buildings are not included in the ground war loss statistics. I think this is a reasonable compromise-- they weren't actually destroyed as part of the battle.