### PR TITLE
Resolve #931 double dekker tanks

### DIFF
--- a/src/hu/openig/screen/items/PlanetScreen.java
+++ b/src/hu/openig/screen/items/PlanetScreen.java
@@ -6333,6 +6333,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
      */
     void placeGroundUnits(boolean atBuildings, LinkedList<GroundwarUnit> gus) {
         Set<Location> locations = getDeploymentLocations(atBuildings, true);
+        locations.removeIf(loc -> unitsAtLocation.get(loc) != null);
         CenterAndRadius car = computePlacementCircle(locations);
         if (atBuildings) {
             placeAroundInCircle(gus, locations, car.icx, car.icy, car.rmax);


### PR DESCRIPTION
Resolves #931

Filter out all the locations already taken by the player, before the non-player's turn for placing units.

The issues was reproduced by forcing the ai to place all units in a prepared corner by hardcoding the initial placement location,
(not I was able to reproduce it with the default random setting but it was a tedious process)

Two units on the same grid space
![double_dekker_tanks](https://github.com/akarnokd/open-ig/assets/115974729/8b8c7520-3bf6-43bb-ae23-5a6428b437f2)

After the fix:
![plain_old_tanks](https://github.com/akarnokd/open-ig/assets/115974729/ffc0a4df-219f-4cd1-b59f-97b5856cc386)


