### PR TITLE
Use unitsForPathFinding for non-player deployment location exclusion

### DIFF
--- a/src/hu/openig/screen/items/PlanetScreen.java
+++ b/src/hu/openig/screen/items/PlanetScreen.java
@@ -6333,7 +6333,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
      */
     void placeGroundUnits(boolean atBuildings, LinkedList<GroundwarUnit> gus) {
         Set<Location> locations = getDeploymentLocations(atBuildings, true);
-        locations.removeAll(unitsAtLocation.keySet());
+        locations.removeAll(unitsForPathfinding.keySet());
         CenterAndRadius car = computePlacementCircle(locations);
         if (atBuildings) {
             placeAroundInCircle(gus, locations, car.icx, car.icy, car.rmax);


### PR DESCRIPTION
I realized from the pictures I provided for the solution of  #931 in PR #1088 that there are still some units that get stacked.
The unitsAtLocation I used originally is shifted by -1 on both axis for rendering purposes.
To resolve this, unitsForPathFinding is now used as that should give the correct grid values to exclude.