### PR TITLE
Changed energy demand calculation for demolishing excess power plants.

### DIFF
--- a/src/hu/openig/mechanics/ColonyPlanner.java
+++ b/src/hu/openig/mechanics/ColonyPlanner.java
@@ -749,7 +749,7 @@ public class ColonyPlanner extends Planner {
     }
 
     /**
-     * Check if there power status of a planet.
+     * Check the power status of a planet.
      * If not enough power build additional power plants.
      * If there is too much unused capacity, remove power plants.
      * @param planet the target planet

--- a/src/hu/openig/mechanics/ColonyPlanner.java
+++ b/src/hu/openig/mechanics/ColonyPlanner.java
@@ -749,14 +749,15 @@ public class ColonyPlanner extends Planner {
     }
 
     /**
-     * Check if there are enough power on the planet,
-     * if not, try adding morale and growth increasing buildings.
+     * Check if there power status of a planet.
+     * If not enough power build additional power plants.
+     * If there is too much unused capacity, remove power plants.
      * @param planet the target planet
      * @return true if action taken
      */
     boolean checkPower(final AIPlanet planet) {
         // sell power plants if too much energy
-        if (planet.statistics.energyAvailable > planet.statistics.energyDemand * 2
+        if (planet.statistics.energyAvailable > planet.statistics.baseEnergyDemand * 1.3
                 && !planet.statistics.constructing) {
             for (final AIBuilding b : planet.buildings) {
                 if (b.getEnergy() > 0 && planet.statistics.energyAvailable - b.getEnergy() > planet.statistics.energyDemand) {

--- a/src/hu/openig/model/Planet.java
+++ b/src/hu/openig/model/Planet.java
@@ -1575,11 +1575,14 @@ public class Planet implements Named, Owned, HasInventory, HasPosition {
 
         addLabs(result.labs, b);
 
+        int e = b.getEnergy();
+        if (e < 0) {
+            result.baseEnergyDemand += -e;
+        }
         float health = b.hitpoints * 1.0f / b.type.hitpoints;
         if (b.isReady()) {
             // consider the damage level
             result.workerDemand += Math.abs(b.getWorkers()) * health;
-            int e = b.getEnergy();
             if (e < 0) {
                 result.energyDemand += -e * health;
             } else {

--- a/src/hu/openig/model/PlanetStatistics.java
+++ b/src/hu/openig/model/PlanetStatistics.java
@@ -99,6 +99,8 @@ public class PlanetStatistics {
     public int policeAvailable;
     /** The energy demand. */
     public int energyDemand;
+    /** The base energy demand of all buildings, whether they are being built, enabled or not. */
+    public int baseEnergyDemand;
     /** The available energy. */
     public int energyAvailable;
     /** The active production values. */
@@ -153,6 +155,7 @@ public class PlanetStatistics {
         foodAvailable += other.foodAvailable;
         policeAvailable += other.policeAvailable;
         energyDemand += other.energyDemand;
+        baseEnergyDemand += other.baseEnergyDemand;
         energyAvailable += other.energyAvailable;
 
         activeLabs.add(other.activeLabs);


### PR DESCRIPTION
Attempt to resolve #988

By adding up the base energy demand of all buildings in a planet regardless of their state, we can get a fixed energy demand value that can be used for deciding the removal of any excess power plants.
Since the values i fixed as it is not affected by worker shortage/building damage it should prevent the oscillating behavior described in the issue.

As this value should give a closer estimate for the expected demand in the near future, the ratio of 2 for energyAvailable/energyDemand can be replaced with a more conservative 1.3 for energyAvailable/baseEnergyDemand for deciding demolishing of a power plant.