### PR TITLE
Resolve #995

### DIFF
--- a/src/hu/openig/model/SpacewarStructure.java
+++ b/src/hu/openig/model/SpacewarStructure.java
@@ -320,4 +320,14 @@ public class SpacewarStructure extends SpacewarObject {
         }
         return null;
     }
+    /**
+     * Returns whether the space structure is a representation of a missile projectile.
+     * @return true if the space structure is a missile
+     */
+    public boolean isMissile() {
+        return type == StructureType.BOMB ||
+                type == StructureType.VIRUS_BOMB ||
+                type == StructureType.ROCKET ||
+                type == StructureType.MULTI_ROCKET;
+    }
 }

--- a/src/hu/openig/screen/items/SpacewarScreen.java
+++ b/src/hu/openig/screen/items/SpacewarScreen.java
@@ -4062,7 +4062,7 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
         int nonplayerUnits = 0;
         Player other = null;
         for (SpacewarStructure s : structures) {
-            if (canControl(s)) {
+            if (canControl(s) || (battle.isAlly(s, player()) || s.isMissile())) {
                 playerUnits++;
             } else {
                 nonplayerUnits++;


### PR DESCRIPTION
Resolve #995 
When determining winner of a space battle player owned missiles are now counted as player units. Otherwise it was possible that player owned missiles were counted as 'other' units and as such the 'other' player became the 'human player' instead of ai player thus win conditions were decided based on 'human player' vs. 'human player'.