### PR TITLE
Reworked groundwar pathfinding

### DIFF
--- a/src/hu/openig/core/AStarSearch.java
+++ b/src/hu/openig/core/AStarSearch.java
@@ -148,7 +148,7 @@ public class AStarSearch<T> {
 
         // if we get here, there was no direct path available
         // find a target location which minimizes initial-L-destination
-        if (closedSet.isEmpty()) {
+        if (closedSet.size() <= 1 || initial.equals(nearest)) {
             return Pair.of(false, Collections.<T>emptyList());
         }
         return Pair.of(true, reconstructPath(cameFrom, nearest));

--- a/src/hu/openig/core/Pathfinding.java
+++ b/src/hu/openig/core/Pathfinding.java
@@ -20,6 +20,8 @@ import java.util.Set;
 public class Pathfinding extends AStarSearch<Location> {
     /** Test for passability. */
     public Func1<Location, Boolean> isPassable;
+    /** Test for permanent obstacles */
+    public Func1<Location, Boolean> isBlocked;
     /** Setup the A*. */
     public Pathfinding() {
         neighbors = new Func1<Location, List<Location>>() {
@@ -35,8 +37,8 @@ public class Pathfinding extends AStarSearch<Location> {
      * @param destination the destination
      * @return the path, empty if the target is completely unreachable
      */
-    public List<Location> searchApproximate(final Location initial, final Location destination) {
-        return search(initial, destination).second;
+    public Pair<Boolean, List<Location>> searchApproximate(final Location initial, final Location destination) {
+        return  search(initial, destination);
     }
     /**
      * Computes the sum of the distance squares between (target and source1) and (target and source2).
@@ -97,42 +99,37 @@ public class Pathfinding extends AStarSearch<Location> {
         Location bottom = current.delta(0, 1);
         Location top = current.delta(0, -1);
 
-        boolean pleft = isPassable.invoke(left);
-        boolean pright = isPassable.invoke(right);
-        boolean pbottom = isPassable.invoke(bottom);
-        boolean ptop = isPassable.invoke(top);
-
-        if (pleft) {
+        if (isPassable.invoke(left)) {
             result.add(left);
         }
-        if (pright) {
+        if (isPassable.invoke(right)) {
             result.add(right);
         }
-        if (pbottom) {
+        if (isPassable.invoke(bottom)) {
             result.add(bottom);
         }
-        if (ptop) {
+        if (isPassable.invoke(top)) {
             result.add(top);
         }
-        if (pleft && ptop) {
+        if (!isBlocked.invoke(left) && !isBlocked.invoke(top)) {
             Location c = current.delta(-1, -1);
             if (isPassable.invoke(c)) {
                 result.add(c);
             }
         }
-        if (pleft && pbottom) {
+        if (!isBlocked.invoke(left) && !isBlocked.invoke(bottom)) {
             Location c = current.delta(-1, 1);
             if (isPassable.invoke(c)) {
                 result.add(c);
             }
         }
-        if (pright && ptop) {
+        if (!isBlocked.invoke(right) && !isBlocked.invoke(top)) {
             Location c = current.delta(1, -1);
             if (isPassable.invoke(c)) {
                 result.add(c);
             }
         }
-        if (pright && pbottom) {
+        if (!isBlocked.invoke(right) && !isBlocked.invoke(bottom)) {
             Location c = current.delta(1, 1);
             if (isPassable.invoke(c)) {
                 result.add(c);

--- a/src/hu/openig/model/GroundwarManager.java
+++ b/src/hu/openig/model/GroundwarManager.java
@@ -153,7 +153,7 @@ public class GroundwarManager implements GroundwarWorld {
 
         @Override
         public PathPlanning call() {
-            path.addAll(getPathfinding(ignore).searchApproximate(current, goal));
+            //path.addAll(getPathfinding(ignore).searchApproximate(current, goal));
             return this;
         }
         /**

--- a/src/hu/openig/model/GroundwarUnit.java
+++ b/src/hu/openig/model/GroundwarUnit.java
@@ -95,17 +95,7 @@ public class GroundwarUnit extends GroundwarObject implements HasLocation, Owned
     }
     @Override
     public Location location() {
-        return Location.of((int)x, (int)y);
-    }
-    /**
-     * Determines the location which should be used for path calculation.
-     * @return the location
-     */
-    public Location pathFindingLocation() {
-        if ((Math.abs(x - (int)x) < 1E-9 && Math.abs(y - (int)y) < 1E-9) || path.isEmpty()) {
-            return Location.of((int)x, (int)y);
-        }
-        return path.get(0);
+        return Location.of((int)Math.round(x), (int)Math.round(y));
     }
     @Override
     public Double exactLocation() {
@@ -147,6 +137,10 @@ public class GroundwarUnit extends GroundwarObject implements HasLocation, Owned
     /** @return true if the unit is moving. */
     public boolean isMoving() {
         return nextMove != null || !path.isEmpty();
+    }
+    /** @return true if the unit is in between cells. */
+    public boolean inMotion()  {
+        return (x % 1 != 0) || (y % 1 != 0);
     }
     /**
      * @return the target cell of movement or null if not moving
@@ -248,41 +242,11 @@ public class GroundwarUnit extends GroundwarObject implements HasLocation, Owned
         return new Point(px + model.width / 2, py + model.height / 2);
     }
     /**
-     * Merges the current path with the new skipping
-     * overlapping parts to avoid unnecessary rotations.
-
+     * Merges the new path.
      * @param newPath the new path to follow
      */
     public void mergePath(List<Location> newPath) {
-        // path.addAll(newPath);
-        if (!newPath.isEmpty()) {
-
-            if (newPath.size() >= 2) {
-                Location p0 = newPath.get(0);
-
-                double vx = p0.x - x;
-                double vy = p0.y - y;
-                double v = Math.hypot(vx, vy);
-
-                if (v >= 1E-9) {
-                    Location p1 = newPath.get(1);
-
-                    double ax = p1.x - p0.x;
-                    double ay = p1.y - p0.y;
-                    double a = Math.hypot(ax, ay);
-
-                    double angle = Math.acos((vx * ax + vy * ay) / v / a);
-                    if (angle >= Math.PI - 1E-6) {
-                        path.clear();
-                        path.addAll(newPath.subList(1, newPath.size()));
-                        nextMove = p1;
-                        nextRotate = p1;
-                        return;
-                    }
-                }
-
-            }
-            path.addAll(newPath);
-        }
+        path.clear();
+        path.addAll(newPath);
     }
 }

--- a/src/hu/openig/model/Planet.java
+++ b/src/hu/openig/model/Planet.java
@@ -90,7 +90,7 @@ public class Planet implements Named, Owned, HasInventory, HasPosition {
     /** The persistent deployed ground units and turrets. */
     public final PlanetGround ground;
     /** The ground war manager for this planet. */
-    public final GroundwarManager war;
+    //public final GroundwarManager war;
     /**
      * Compares the total value of the planet.
      */
@@ -135,7 +135,7 @@ public class Planet implements Named, Owned, HasInventory, HasPosition {
         this.id = id;
         this.world = world;
         this.ground = new PlanetGround();
-        this.war = new GroundwarManager(this);
+        //this.war = new GroundwarManager(this);
     }
     /**
      * Return the morale label for the given level.


### PR DESCRIPTION
Reworked the groundwar pathfinding. Did not touch much the overall infrastructure and AI logic. It mostly changes how passability checks are made and re-pathing strategy.

Some issues fixed:
- Unit location does not snap to the correct cell for pathfinding when moving diagonally in a horizontal line.
- Sometimes direct move orders get overwritten by attack orders that come from guard mode
- Minor things I might have forgot to note down as there was a lot of trial and error involved.

Non exhaustive list of changes:
- Replaced yielding with tile reservation and more aggressive re-pathing.
Tile reservation is used instead of collision detection. This avoids issues that could come from fractional location coordinates, where multiple units might occupy the same node for pathing purposes. A tile is reserved by a unit as it starts its movement into it. The reservation is cleared when it arrives in the target cell. 
- diagonal movement is only prohibited if the top/bottom/left/right cells are permanently impassable.  This the same as in the original. Also makes group movement pathing much cleaner,
- Pathing requests are now stored in a LinkedHashMap for queing and discarding redundant requests of the same unit. This allows for more aggressive re-pathing requests without flooding the pathing queue and makes sure everyone gets their turn.
- do occasional re-pathing between cells. Rate is currently 1/10 chance when between movement steps. Seems to work OK.
- blocking objects considered temporary and thus ignored are:
   + enemy units in case of attack move(same as before)
   + friendly units in motion (fractional location or in rotation sequence)
   + inMotionPlanning no longer used
- Group move order now gives each selected unit a destination location around the initially ordered location based on it's relative location within the group. This helps to avoid competing for the same destination location and preventing units moving in a single file. Attack move remained the same with a single destination, only they pile up a bit slower if they arrive at that destination.
- attacking units re-path only if their target moves out of their maxRange relative to the original path destination.
- If a unit can't find a path try again x times before giving up.
- Treat paths of length 1 as empty as the first node is the one under the unit
- Readjust goal location if original goal is blocked by a unit standing still
- Merge pathing logic not needed as now all re-paths happen in stable(roundNum,roundNum) positions
- changed how commands are shown in debug mode and added some extra information about tiles that are taken ore reserved by a unit.

Side note:
- Removed the GroundWarManager from planet object as it is currently not used. What should be do with that?

Example videos:
https://drive.google.com/file/d/1Bd2k24DwUuamReztlFiDN7TmdGroS_HL/view?usp=drive_link
https://drive.google.com/file/d/1uS8y2frbkkevi6M51F4Krti80pg5hYrs/view?usp=drive_link