### PR TITLE
Added interpolated unit and projectile movement to ground battles

### DIFF
--- a/src/hu/openig/model/GroundwarRocket.java
+++ b/src/hu/openig/model/GroundwarRocket.java
@@ -19,6 +19,10 @@ public class GroundwarRocket extends GroundwarObject {
     public double x;
     /** The current cell coordinate. */
     public double y;
+    /** The previous cell coordinate. */
+    public double lastX;
+    /** The previous cell coordinate. */
+    public double lastY;
     /** The target cell point. */
     public double targetX;
     /** The target cell point. */

--- a/src/hu/openig/model/GroundwarUnit.java
+++ b/src/hu/openig/model/GroundwarUnit.java
@@ -31,6 +31,10 @@ public class GroundwarUnit extends GroundwarObject implements HasLocation, Owned
     public double x;
     /** The position with fractional precision in surface coordinates. */
     public double y;
+    /** The previous position with fractional precision in surface coordinates. */
+    public double lastX;
+    /** The previous position with fractional precision in surface coordinates. */
+    public double lastY;
     /** The available hitpoints. */
     public double hp;
     /** The original inventory item. */


### PR DESCRIPTION
Added interpolation to unit and projectile movement in ground battles to smooth out movement on lower simulation speeds.
For this I separated simulation and rendering timers during ground battles. A new timer was added for submitting painting requests with a delay same as on ultra fast sim speed(~40fps).

Also found that the simulation timer for running test battles outside of a groundwar(ctrl+d) was always running affecting proper timings, I moved that to activate only when the test battle is started.