### PR TITLE
Fixed an issue where an in motion unit would use the wrong starting location for pathing requests.

### DIFF
--- a/src/hu/openig/mechanics/AIGroundwar.java
+++ b/src/hu/openig/mechanics/AIGroundwar.java
@@ -80,7 +80,7 @@ public class AIGroundwar {
             um.remove(u.target());
         }
         for (final GroundwarUnit u : minelayers) {
-            if (!u.isMoving() && u.phase == 0) {
+            if (!u.isMoving() && u.fireAnimPhase == 0) {
                 Location l = u.location();
                 SurfaceEntity e = war.planet().surface.buildingmap.get(l);
                 if (e != null && e.type == SurfaceEntityType.ROAD

--- a/src/hu/openig/model/BattleGroundVehicle.java
+++ b/src/hu/openig/model/BattleGroundVehicle.java
@@ -22,7 +22,7 @@ public class BattleGroundVehicle {
     /** The destruction sound. */
     public SoundType destroy;
     /** The fire sound if non null. */
-    public SoundType fire;
+    public SoundType fireSound;
     /** The explosion to play. */
     public ExplosionType explosion;
     /** The hitpoints. */

--- a/src/hu/openig/model/GroundwarManager.java
+++ b/src/hu/openig/model/GroundwarManager.java
@@ -862,29 +862,29 @@ public class GroundwarManager implements GroundwarWorld {
         if (ground.minelayers.contains(u) && u.path.size() == 0) {
             Location loc = u.location();
             if (!ground.mines.containsKey(loc)) {
-                u.phase++;
-                if (u.phase >= u.maxPhase()) {
+                u.fireAnimPhase++;
+                if (u.fireAnimPhase >= u.maxPhase()) {
                     Mine m = new Mine();
                     m.damage = u.damage();
                     m.owner = u.owner;
                     ground.mines.put(loc, m);
                     ground.minelayers.remove(u);
-                    u.phase = 0;
+                    u.fireAnimPhase = 0;
                 }
             } else {
                 ground.minelayers.remove(u);
             }
         } else
-        if (u.phase > 0) {
-            u.phase++;
-            if (u.phase >= u.maxPhase()) {
+        if (u.fireAnimPhase > 0) {
+            u.fireAnimPhase++;
+            if (u.fireAnimPhase >= u.maxPhase()) {
                 if (u.attackUnit != null) {
                     attackUnitEndPhase(u);
                 } else
                 if (u.attackBuilding != null) {
                     attackBuildingEndPhase(u);
                 }
-                u.phase = 0;
+                u.fireAnimPhase = 0;
 
                 if (u.hasValidTarget()
 
@@ -1029,9 +1029,9 @@ public class GroundwarManager implements GroundwarWorld {
             } else
             if (rotateStep(u, centerCellOf(u.attackBuilding))) {
                 if (u.cooldown <= 0) {
-                    u.phase++;
-                    if (u.model.fire != null) {
-                        playSounds.add(u.model.fire);
+                    u.fireAnimPhase++;
+                    if (u.model.fireSound != null) {
+                        playSounds.add(u.model.fireSound);
                     }
 
                     if (u.model.type == GroundwarUnitType.ROCKET_SLED) {
@@ -1128,9 +1128,9 @@ public class GroundwarManager implements GroundwarWorld {
             } else
             if (rotateStep(u, u.attackUnit.location())) {
                 if (u.cooldown <= 0) {
-                    u.phase++;
-                    if (u.model.fire != null) {
-                        playSounds.add(u.model.fire);
+                    u.fireAnimPhase++;
+                    if (u.model.fireSound != null) {
+                        playSounds.add(u.model.fireSound);
                     }
                     if (u.model.type == GroundwarUnitType.PARALIZER) {
                         if (u.attackUnit.paralized == null) {
@@ -1262,13 +1262,13 @@ public class GroundwarManager implements GroundwarWorld {
         double powerRate = 1d * g.building.assignedEnergy / g.building.getEnergy();
         double indexRate = (g.index + 0.5) / g.count;
         if (indexRate >= powerRate) {
-            g.phase = 0;
+            g.fireAnimPhase = 0;
             return;
         }
 
-        if (g.phase > 0) {
-            g.phase++;
-            if (g.phase >= g.maxPhase()) {
+        if (g.fireAnimPhase > 0) {
+            g.fireAnimPhase++;
+            if (g.fireAnimPhase >= g.maxPhase()) {
                 if (g.attack != null && !g.attack.isDestroyed()
 
                         && g.inRange(g.attack)) {
@@ -1291,7 +1291,7 @@ public class GroundwarManager implements GroundwarWorld {
                     }
                 }
                 g.cooldown = g.model.delay;
-                g.phase = 0;
+                g.fireAnimPhase = 0;
             }
         } else {
             if (g.attack != null && !g.attack.isDestroyed()
@@ -1299,7 +1299,7 @@ public class GroundwarManager implements GroundwarWorld {
                     && g.inRange(g.attack)) {
                 if (rotateStep(g, g.attack.center())) {
                     if (g.cooldown <= 0) {
-                        g.phase++;
+                        g.fireAnimPhase++;
                         playSounds.add(g.model.fire);
                     } else {
                         g.cooldown -= SIMULATION_DELAY;
@@ -1678,7 +1678,7 @@ public class GroundwarManager implements GroundwarWorld {
             double angle = Math.atan2(rocket.targetY - rocket.y, rocket.targetX - rocket.x);
             rocket.x += dv * Math.cos(angle);
             rocket.y += dv * Math.sin(angle);
-            rocket.phase++;
+            rocket.fireAnimPhase++;
 
             if (isRocketJammed(rocket, 0.5)) {
                 createExplosion(rocket.x, rocket.y, ExplosionType.GROUND_ROCKET_2);
@@ -1701,8 +1701,8 @@ public class GroundwarManager implements GroundwarWorld {
                     && u.model.type == GroundwarUnitType.ROCKET_JAMMER && u.paralizedTTL == 0) {
                 double distance = Math.hypot(u.x - rocket.x, u.y - rocket.y);
                 if (distance < u.model.maxRange * penetrationRatio) {
-                    if (u.phase == 0) {
-                        u.phase++;
+                    if (u.fireAnimPhase == 0) {
+                        u.fireAnimPhase++;
                     }
                     return true;
                 }

--- a/src/hu/openig/model/GroundwarObject.java
+++ b/src/hu/openig/model/GroundwarObject.java
@@ -18,7 +18,7 @@ public abstract class GroundwarObject {
     /** The facing angle. */
     public double angle;
     /** The fire animation phase. */
-    public int phase;
+    public int fireAnimPhase;
     /** The owner. */
     public Player owner;
     /** The cached angle. */
@@ -39,7 +39,7 @@ public abstract class GroundwarObject {
     }
     /** @return Get the image for the current rotation and phase. */
     public BufferedImage get() {
-        BufferedImage[] rotation = matrix[phase % matrix.length];
+        BufferedImage[] rotation = matrix[fireAnimPhase % matrix.length];
 
         if (cachedAngle != angle) {
             double a = normalizedAngle() / 2 / Math.PI;

--- a/src/hu/openig/model/GroundwarUnit.java
+++ b/src/hu/openig/model/GroundwarUnit.java
@@ -16,8 +16,8 @@ import java.awt.Rectangle;
 import java.awt.geom.Point2D;
 import java.awt.geom.Point2D.Double;
 import java.awt.image.BufferedImage;
-import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -48,7 +48,7 @@ public class GroundwarUnit extends GroundwarObject implements WarUnit {
     /** The weapon cooldown counter. */
     public int cooldown;
     /** The current movement path to the target. */
-    public final List<Location> path = new ArrayList<>();
+    public final LinkedList<Location> path = new LinkedList<>();
     /** The next move rotation. */
     public Location nextRotate;
     /** The next move location. */

--- a/src/hu/openig/model/SpacewarStructure.java
+++ b/src/hu/openig/model/SpacewarStructure.java
@@ -208,6 +208,14 @@ public class SpacewarStructure extends SpacewarObject implements WarUnit {
     public Location nextRotate() {
         return nextRotate;
     }
+    /** @return true if the unit is moving. */
+    public boolean isMoving() {
+        return nextMove != null || !path.isEmpty();
+    }
+    /** @return true if the unit is in between cells. */
+    public boolean inMotion()  {
+        return (x % 1 != 0) || (y % 1 != 0);
+    }
     @Override
     public Player owner() {
         return owner;

--- a/src/hu/openig/model/WarUnit.java
+++ b/src/hu/openig/model/WarUnit.java
@@ -26,6 +26,10 @@ public interface WarUnit extends HasLocation, Owned {
     Location nextMove();
     /** @return next rotation target location of the WarUnit. */
     Location nextRotate();
+    /** @return true if the unit is moving. */
+     boolean isMoving();
+    /** @return true if the unit is in between cells. */
+    boolean inMotion();
     /**
      * Merges the new path.
      * @param newPath the new path to follow

--- a/src/hu/openig/model/World.java
+++ b/src/hu/openig/model/World.java
@@ -2474,7 +2474,7 @@ public class World implements ModelLookup {
             }
             ge.destroy = SoundType.valueOf(xground.get("destroy"));
             if (xground.has("fire")) {
-                ge.fire = SoundType.valueOf(xground.get("fire"));
+                ge.fireSound = SoundType.valueOf(xground.get("fire"));
             }
 
             ge.hp = xground.getInt("hp");

--- a/src/hu/openig/screen/items/PlanetScreen.java
+++ b/src/hu/openig/screen/items/PlanetScreen.java
@@ -1683,7 +1683,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                     } else
                     if (u.path.size() > 0) {
                         g2.setColor(u.attackMove != null ? Color.RED : Color.GREEN);
-                        Location gl = u.path.get(u.path.size() - 1);
+                        Location gl = u.path.peekLast();
                         int gx = x0 + Tile.toScreenX(gl.x, gl.y) + 27;
                         int gy = y0 + Tile.toScreenY(gl.x, gl.y) + 14;
                         g2.drawLine(gx, gy, up.x, up.y);
@@ -4642,7 +4642,11 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
         PathPlanning(
                 WarUnit unit,
                 Location goal) {
-            this.current = unit.location();
+            if (unit.inMotion() && (unit.nextMove() != null) && (unit.location() != unit.nextMove())) {
+                this.current = unit.nextMove();
+            } else {
+                this.current = unit.location();
+            }
             this.goal = goal;
             this.unit = unit;
         }
@@ -4699,11 +4703,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
         if (selection.size() == 1) {
             GroundwarUnit u = selection.get(0);
             moved = true;
-            u.attackUnit = null;
-            u.attackBuilding = null;
-            u.attackMove = null;
-            u.advanceOnUnit = null;
-            u.advanceOnBuilding = null;
+            stop(u);
             move(u, lm.x, lm.y);
         } else {
             // Group units up nicely so paths to the generated destinations will intersect each other less
@@ -4787,11 +4787,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
             });
             Iterator<Location> iter = targetLocations.iterator();
             for (GroundwarUnit unit : selection) {
-                unit.attackUnit = null;
-                unit.attackBuilding = null;
-                unit.attackMove = null;
-                unit.advanceOnUnit = null;
-                unit.advanceOnBuilding = null;
+                stop(unit);
                 Location assignedLocation = iter.next();
                 move(unit, assignedLocation.x, assignedLocation.y);
             }
@@ -5163,29 +5159,29 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
         if (minelayers.contains(u) && u.path.size() == 0) {
             Location loc = u.location();
             if (!mines.containsKey(loc)) {
-                u.phase++;
-                if (u.phase >= u.maxPhase()) {
+                u.fireAnimPhase++;
+                if (u.fireAnimPhase >= u.maxPhase()) {
                     Mine m = new Mine();
                     m.damage = u.damage();
                     m.owner = u.owner;
                     mines.put(loc, m);
                     minelayers.remove(u);
-                    u.phase = 0;
+                    u.fireAnimPhase = 0;
                 }
             } else {
                 minelayers.remove(u);
             }
         } else
-        if (u.phase > 0) {
-            u.phase++;
-            if (u.phase >= u.maxPhase()) {
+        if (u.fireAnimPhase > 0) {
+            u.fireAnimPhase++;
+            if (u.fireAnimPhase >= u.maxPhase()) {
                 if (u.attackUnit != null) {
                     attackUnitEndPhase(u);
                 } else
                 if (u.attackBuilding != null) {
                     attackBuildingEndPhase(u);
                 }
-                u.phase = 0;
+                u.fireAnimPhase = 0;
 
                 if (u.hasValidTarget()
 
@@ -5296,16 +5292,16 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
         }
         List<Location> neighbors = getPathfinding(u).neighbors.invoke(source);
         if (!neighbors.isEmpty()) {
-            Location cell = null;
+            Location cellCloserToTarget = null;
             double cellDistance = currentDistance;
             for (Location loc : neighbors) {
                 double newDistance = Math.hypot(tx - loc.x, ty - loc.y);
                 if (newDistance < cellDistance) {
                     cellDistance = newDistance;
-                    cell = loc;
+                    cellCloserToTarget = loc;
                 }
             }
-            if (cell != null) {
+            if (cellCloserToTarget != null) {
                 if (u.attackUnit != null) {
                     u.advanceOnUnit = u.attackUnit;
                     u.attackUnit = null;
@@ -5314,7 +5310,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                     u.advanceOnBuilding = u.attackBuilding;
                     u.attackBuilding = null;
                 }
-                pathsToPlan.put(u, new PathPlanning(u, cell));
+                pathsToPlan.put(u, new PathPlanning(u, cellCloserToTarget));
             }
         }
     }
@@ -5327,12 +5323,11 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
             if (u.nextMove != null) {
                 u.path.clear();
                 u.path.add(u.nextMove);
-            } else
-            if (rotateStep(u, centerCellOf(u.attackBuilding))) {
+            } else if (rotateStep(u, centerCellOf(u.attackBuilding))) {
                 if (u.cooldown <= 0) {
-                    u.phase++;
-                    if (u.model.fire != null) {
-                        effectSound(u.model.fire);
+                    u.fireAnimPhase++;
+                    if (u.model.fireSound != null) {
+                        effectSound(u.model.fireSound);
                     }
 
                     if (u.model.type == GroundwarUnitType.ROCKET_SLED) {
@@ -5424,9 +5419,9 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
             } else
             if (rotateStep(u, u.attackUnit.location())) {
                 if (u.cooldown <= 0) {
-                    u.phase++;
-                    if (u.model.fire != null) {
-                        effectSound(u.model.fire);
+                    u.fireAnimPhase++;
+                    if (u.model.fireSound != null) {
+                        effectSound(u.model.fireSound);
                     }
                     if (u.model.type == GroundwarUnitType.PARALIZER) {
                         if (u.attackUnit.paralized == null) {
@@ -5463,7 +5458,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                 }
             } else {
                 if (u.attackMove == null) {
-                    Location ep = u.path.get(u.path.size() - 1);
+                    Location ep = u.path.peekLast();
                     // if the target unit moved since last
                     double dx = ep.x - u.attackUnit.x;
                     double dy = ep.y - u.attackUnit.y;
@@ -5594,13 +5589,13 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
         double powerRate = 1d * g.building.assignedEnergy / g.building.getEnergy();
         double indexRate = (g.index + 0.5) / g.count;
         if (indexRate >= powerRate) {
-            g.phase = 0;
+            g.fireAnimPhase = 0;
             return;
         }
 
-        if (g.phase > 0) {
-            g.phase++;
-            if (g.phase >= g.maxPhase()) {
+        if (g.fireAnimPhase > 0) {
+            g.fireAnimPhase++;
+            if (g.fireAnimPhase >= g.maxPhase()) {
                 if (g.attack != null && !g.attack.isDestroyed()
 
                         && unitInRange(g, g.attack)) {
@@ -5623,7 +5618,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                     }
                 }
                 g.cooldown = g.model.delay;
-                g.phase = 0;
+                g.fireAnimPhase = 0;
             }
         } else {
             if (g.attack != null && !g.attack.isDestroyed()
@@ -5631,7 +5626,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                     && unitInRange(g, g.attack)) {
                 if (rotateStep(g, centerOf(g.attack))) {
                     if (g.cooldown <= 0) {
-                        g.phase++;
+                        g.fireAnimPhase++;
                         effectSound(g.model.fire);
                     } else {
                         g.cooldown -= SIMULATION_DELAY;
@@ -5980,7 +5975,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
      */
     void repath(final GroundwarUnit u) {
         if (u.path.size() > 1) {
-            final Location goal = u.path.get(u.path.size() - 1);
+            final Location goal = u.path.peekLast();
             u.path.clear();
             u.nextMove = null;
             u.nextRotate = null;
@@ -6003,7 +5998,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                 repath(u);
                 return;
             }
-            u.nextMove = u.path.get(0);
+            u.nextMove = u.path.peekFirst();
             u.nextRotate = u.nextMove;
 
             // is the next move location still passable?
@@ -6018,7 +6013,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
         if (unitsForPathfinding.get(u.nextMove) != null) {
             for (GroundwarUnit gunit : unitsForPathfinding.get(u.nextMove)) {
                 if ((gunit != u) && !gunit.inMotion() && !needsRotation(gunit, gunit.nextMove)) {
-                    if (u.nextMove == u.path.get(u.path.size() - 1)) {
+                    if (u.nextMove == u.path.peekLast()) {
                         int baseX = u.nextMove.x;
                         int baseY = u.nextMove.y;
                         outer:
@@ -6090,10 +6085,10 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
             updateUnitLocation(u, u.nextMove.x, u.nextMove.y, false);
 
             u.nextMove = null;
-            u.path.remove(0);
+            u.path.removeFirst();
             double remaining = dv - distanceToTarget;
             if (!u.path.isEmpty()) {
-                Location nextCell = u.path.get(0);
+                Location nextCell = u.path.peekFirst();
                 if (!needsRotation(u, nextCell)) {
                     double tempX = u.lastX;
                     double tempY = u.lastY;
@@ -6344,7 +6339,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
             rocket.lastY = rocket.y;
             rocket.x += dv * Math.cos(angle);
             rocket.y += dv * Math.sin(angle);
-            rocket.phase++;
+            rocket.fireAnimPhase++;
 
             if (isRocketJammed(rocket, 0.5)) {
                 Point p = centerOf(rocket.x, rocket.y);
@@ -6368,8 +6363,8 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                     && u.model.type == GroundwarUnitType.ROCKET_JAMMER && u.paralizedTTL == 0) {
                 double distance = Math.hypot(u.x - rocket.x, u.y - rocket.y);
                 if (distance < u.model.maxRange * penetrationRatio) {
-                    if (u.phase == 0) {
-                        u.phase++;
+                    if (u.fireAnimPhase == 0) {
+                        u.fireAnimPhase++;
                     }
                     return true;
                 }
@@ -6956,7 +6951,6 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
     }
     @Override
     public void move(GroundwarUnit u, int x, int y) {
-        stop(u);
         u.guard = true;
         Location lm = Location.of(x, y);
         pathsToPlan.put(u, new PathPlanning(u, lm));


### PR DESCRIPTION
Fixed an issue where an in motion unit would use the wrong starting location for pathing requests.
This caused that unit could walk through non-passable locations if a new move order (or pathing request) was given when the unit is in the process of moving to the next cell but technically is still in it's starting point cell. When the unit arrived in the next cell it would follow the new path bee-lining to the new path's first location walking through everything in between.

Now when a new pathing request is made, if the unit is in motion but is still located in the starting cell, then the nextMove(soon to be current) cell will be used as the starting point of the new pathing request, so the unit can continue moving seamlessly once arriving in nextMove cell.

Also changed the unit path to use LinkedList instead of ArrayList as in all cases only the first and last elements are accessed.
This somehow also fixed #1121. How this fixed it I have no idea but since using a LinkedList I could not reproduce that problem.

Renamed a few fields and variables while debugging to be a bit more specific.
