### PR TITLE
Added the option to set planet surface exceptions to buildings on a race-by-race basis

### DIFF
--- a/data/generic/campaign/main/buildings.xml
+++ b/data/generic/campaign/main/buildings.xml
@@ -1098,14 +1098,14 @@
   </building>
   <building name='buildings.park' id='Park'>
     <graphics>
-      <tech id='human' height='6' width='6' image='colony/buildings/human/park'/>
-      <tech id='garthog' height='6' width='6' image='colony/buildings/garthog/park' skirmish-only="true"/>
-      <tech id='ecalep' height='6' width='6' image='colony/buildings/ecalep/park' skirmish-only="true"/>
-      <tech id='sullep' height='6' width='6' image='colony/buildings/sullep/park' skirmish-only="true"/>
-      <tech id='ychom' height='5' width='6' image='colony/buildings/ychom/park' skirmish-only="true"/>
-      <tech id='dribs' height='6' width='6' image='colony/buildings/dribs/park' skirmish-only="true"/>
-      <tech id='morgath' height='3' width='3' image='colony/buildings/morgath/park' skirmish-only="true"/>
-      <tech id='dargslan' height='6' width='7' image='colony/buildings/dargslan/park' skirmish-only="true"/>
+      <tech id='human' height='6' width='6' image='colony/buildings/human/park' except="desert,frozen,cratered,liquid,neptoplasm"/>
+      <tech id='garthog' height='6' width='6' image='colony/buildings/garthog/park' skirmish-only="true" except="rocky,desert,cratered,liquid,neptoplasm"/>
+      <tech id='ecalep' height='6' width='6' image='colony/buildings/ecalep/park' skirmish-only="true" except="earth,rocky,desert,frozen,cratered"/>
+      <tech id='sullep' height='6' width='6' image='colony/buildings/sullep/park' skirmish-only="true" except="earth,frozen,cratered,liquid,neptoplasm"/>
+      <tech id='ychom' height='5' width='6' image='colony/buildings/ychom/park' skirmish-only="true" except="earth,desert,frozen,liquid,neptoplasm"/>
+      <tech id='dribs' height='6' width='6' image='colony/buildings/dribs/park' skirmish-only="true" except="desert,frozen,cratered,liquid,neptoplasm"/>
+      <tech id='morgath' height='3' width='3' image='colony/buildings/morgath/park' skirmish-only="true" except="earth,rocky,cratered,liquid,neptoplasm"/>
+      <tech id='dargslan' height='6' width='7' image='colony/buildings/dargslan/park' skirmish-only="true" except="earth,rocky,desert,cratered,neptoplasm"/>
     </graphics>
     <build limit='*' kind='Social' cost='14000'/>
     <operation>

--- a/data/generic/schemas/buildings.xsd
+++ b/data/generic/schemas/buildings.xsd
@@ -124,6 +124,12 @@
 				<xs:documentation>The race-specific building should only be present in skirmish games.</xs:documentation>
 			</xs:annotation>
 		</xs:attribute>
+		<xs:attribute name="except" type="string-list" use="optional">
+			<xs:annotation>
+				<xs:documentation>The list of planet surface types where the
+					building can't be built.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
 	</xs:complexType>
 	<xs:complexType name="build">
 		<xs:annotation>

--- a/src/hu/openig/model/BuildingModel.java
+++ b/src/hu/openig/model/BuildingModel.java
@@ -19,6 +19,7 @@ import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -239,6 +240,13 @@ public class BuildingModel {
                                 }
                                 synchronized (b.tileset) {
                                     b.tileset.put(rid, ts);
+                                }
+
+                                String except = r.get("except", null);
+                                if (except != null && !except.isEmpty()) {
+                                    synchronized (b.raceExcept) {
+                                        b.raceExcept.put(rid, new HashSet<String>(Arrays.asList(except.split("\\s*,\\s*"))));
+                                    }
                                 }
                             }
                         } finally {

--- a/src/hu/openig/model/BuildingType.java
+++ b/src/hu/openig/model/BuildingType.java
@@ -29,6 +29,8 @@ public class BuildingType {
     public String description;
     /** The tile set for various race (more like techraces). */
     public final Map<String, TileSet> tileset = new HashMap<>();
+    /** The planet type (surface) exception set for individual races. Takes precedence over the common exceptions set. */
+    public final Map<String, Set<String>> raceExcept = new HashMap<>();
     /** The hit point amount. */
     public int hitpoints;
     /** The build cost. */
@@ -39,7 +41,7 @@ public class BuildingType {
     public int limit;
     /** In skirmish, use the default limit if the unlimited option is chosen. */
     public boolean skirmishHardLimit;
-    /** The planet type (surface) exception set. */
+    /** The planet type (surface) exception set common for all race variations of the building. */
     public final Set<String> except = new HashSet<>();
     /** The required research to be available. */
     public ResearchType research;

--- a/src/hu/openig/model/Planet.java
+++ b/src/hu/openig/model/Planet.java
@@ -461,7 +461,11 @@ public class Planet implements Named, Owned, HasInventory, HasPosition {
             BuildingType bt,
             boolean checkLimit) {
         // check if this planet type is on the exception list
-        if (bt.except.contains(planet.type.type)) {
+        if (bt.raceExcept.containsKey(planet.race)) {
+            if (bt.raceExcept.get(planet.race).contains(planet.type.type)) {
+                return false;
+            }
+        } else if (bt.except.contains(planet.type.type)) {
             return false;
         }
         // check if the required research is available


### PR DESCRIPTION
Added the option to set planet surface exceptions to buildings on a race-by-race basis.
Fixed parks buildable on all planet types.

For non-human races I added restrictions based on the park's graphics itself and the most favorable surface type for population growth.
The list of planet types that are allowed for building parks for each race:
garthog: earth, frozen
ecalep: neptoplasm, rocky
sullep: desert, rocky
ychom: rocky, cratered
dribs: earth, rocky
morgath: desert, frozen
dargslan: liquid, frozen