### PR TITLE
Pathing rework 2

### DIFF
--- a/data/de/labels.xml
+++ b/data/de/labels.xml
@@ -42,6 +42,7 @@
 	<entry key='settings.video_volume'>Video Lautstärke</entry>
 	<entry key='settings.subtitles'>Untertitel</entry>
 	<entry key='settings.animatetech'>Technologie animieren</entry>
+    <entry key='settings.freeform_movement'>Use freeform movement scheme in spacewar battles</entry>
 	<entry key='settings.reequip_tanks'>Flotte automatisch mit Panzern ausrüsten</entry>
 	<entry key='settings.reequip_bombs'>Flotte automatisch mit Raketen ausrüsten</entry>
 	<entry key='settings.computer_voice_screen'>Computerstimme bei Bildschirmumschaltung</entry>

--- a/data/en/labels.xml
+++ b/data/en/labels.xml
@@ -1853,6 +1853,7 @@
   <entry key='settings.computer_voice_notify'>Computer voice for notification</entry>
   <entry key='settings.computer_voice_screen'>Computer voice for screen switch</entry>
   <entry key='settings.custom_cursors'>Custom cursors</entry>
+  <entry key='settings.freeform_movement'>Use freeform movement scheme in spacewar battles</entry>
   <entry key='settings.gameplay'>Gameplay</entry>
   <entry key='settings.load_save'>Load / Save</entry>
   <entry key='settings.music_volume'>Music volume</entry>

--- a/data/es/labels.xml
+++ b/data/es/labels.xml
@@ -1056,6 +1056,7 @@
 	<entry key="skirmish.social_morale">Moral mínima:</entry>
 	<entry key="Garthog.pirates">Piratas Garthog</entry>
 	<entry key="settings.starmap_panels">Paneles Starmap:</entry>
+	<entry key='settings.freeform_movement'>Use freeform movement scheme in spacewar battles</entry>
 	<entry key="settings.building_text_backgrounds">Resalte los nombres de los edificios y los porcentajes</entry>
 	<entry key="multiplayer.settings.remote_address">Dirección remota:</entry>
 	<entry key="profiles.select_button">Seleccionar / Crear</entry>

--- a/data/fr/labels.xml
+++ b/data/fr/labels.xml
@@ -2564,6 +2564,7 @@
   <entry key='settings.auto_display_objectives'>Automatically display objective changes</entry>
   <entry key='settings.continuous_money'>Calcul du moral et de l&#39;argent en temps réel</entry>
   <entry key='settings.day_night_effects'>Cycle jour/nuit</entry>
+  <entry key='settings.freeform_movement'>Use freeform movement scheme in spacewar battles</entry>
   <entry key='settings.fullscreen'>Plein écran</entry>
   <entry key='settings.gameplay'>Jouabilité</entry>
   <entry key='settings.load_save'>Sauvegardes</entry>

--- a/data/hu/labels.xml
+++ b/data/hu/labels.xml
@@ -989,6 +989,7 @@
 	<entry key='settings.sound_volume'>Hanghatás hangerő</entry>
 	<entry key='settings.music_volume'>Zene hangerő</entry>
 	<entry key='settings.video_volume'>Videó hangerő</entry>
+	<entry key='settings.freeform_movement'>Hajók szabadon mozoghatnak űr harcban</entry>
 	<entry key='settings.reequip_tanks'>Tankok újrafeltöltése csata után</entry>
 	<entry key='settings.reequip_bombs'>Bombák/rakéták újrafeltöltése csata után</entry>
 	<entry key='settings.computer_voice_screen'>Számítógép hang képernyőváltáskor</entry>

--- a/data/ru/labels.xml
+++ b/data/ru/labels.xml
@@ -2374,6 +2374,7 @@
   <entry key='settings.confirm_overwrite'>Перезаписать игру?</entry>
   <entry key='settings.confirm_quit'>Покидаете игру?</entry>
   <entry key='settings.fullscreen'>Полный экран</entry>
+  <entry key='settings.freeform_movement'>Use freeform movement scheme in spacewar battles</entry>
   <entry key='settings.gameplay'>Игра...</entry>
   <entry key='settings.load_save'>Загрузить / Сохранить</entry>
   <entry key='settings.movie_click_skip'>Пропускать видеоролики по клику мыши</entry>

--- a/src/hu/openig/core/Pathfinding.java
+++ b/src/hu/openig/core/Pathfinding.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Class implementing the pathfinding algorithms for ground battles.
+ * Class implementing the pathfinding algorithms.
  * @author akarnokd, 2011.09.06.
  */
 public class Pathfinding extends AStarSearch<Location> {
@@ -30,7 +30,43 @@ public class Pathfinding extends AStarSearch<Location> {
                 return neighbors(value);
             }
         };
+
+        this.estimation = defaultEstimator;
+        this.distance = defaultDistance;
+        this.trueDistance = defaultTrueDistance;
     }
+
+    /**
+     * The default estimator for distance away from the target.
+     */
+    final Func2<Location, Location, Integer> defaultEstimator = new Func2<Location, Location, Integer>() {
+        @Override
+        public Integer invoke(Location t, Location u) {
+            return (Math.abs(t.x - u.x) + Math.abs(t.y - u.y)) * 1000;
+        }
+    };
+
+    /** Routine that tells the distance between two neighboring locations. */
+    final Func2<Location, Location, Integer> defaultDistance = new Func2<Location, Location, Integer>() {
+        @Override
+        public Integer invoke(Location t, Location u) {
+            if (t.x == u.x || u.y == t.y) {
+                return 1000;
+            }
+            return 1414;
+        }
+    };
+
+    /**
+     * Computes the distance between any cells.
+     */
+    final Func2<Location, Location, Integer> defaultTrueDistance = new Func2<Location, Location, Integer>() {
+        @Override
+        public Integer invoke(Location t, Location u) {
+            return (int)(1000 * Math.hypot(t.x - u.x, t.y - u.y));
+        }
+    };
+
     /**
      * Search for a path leading closest to the given destination.
      * @param initial the initial location
@@ -99,39 +135,39 @@ public class Pathfinding extends AStarSearch<Location> {
         Location bottom = current.delta(0, 1);
         Location top = current.delta(0, -1);
 
-        if (isPassable.invoke(left)) {
+        if (!isBlocked.invoke(left) && isPassable.invoke(left)) {
             result.add(left);
         }
-        if (isPassable.invoke(right)) {
+        if (!isBlocked.invoke(right) && isPassable.invoke(right)) {
             result.add(right);
         }
-        if (isPassable.invoke(bottom)) {
+        if (!isBlocked.invoke(bottom) && isPassable.invoke(bottom)) {
             result.add(bottom);
         }
-        if (isPassable.invoke(top)) {
+        if (!isBlocked.invoke(top) && isPassable.invoke(top)) {
             result.add(top);
         }
         if (!isBlocked.invoke(left) && !isBlocked.invoke(top)) {
             Location c = current.delta(-1, -1);
-            if (isPassable.invoke(c)) {
+            if (!isBlocked.invoke(c) && isPassable.invoke(c)) {
                 result.add(c);
             }
         }
         if (!isBlocked.invoke(left) && !isBlocked.invoke(bottom)) {
             Location c = current.delta(-1, 1);
-            if (isPassable.invoke(c)) {
+            if (!isBlocked.invoke(c) && isPassable.invoke(c)) {
                 result.add(c);
             }
         }
         if (!isBlocked.invoke(right) && !isBlocked.invoke(top)) {
             Location c = current.delta(1, -1);
-            if (isPassable.invoke(c)) {
+            if (!isBlocked.invoke(c) && isPassable.invoke(c)) {
                 result.add(c);
             }
         }
         if (!isBlocked.invoke(right) && !isBlocked.invoke(bottom)) {
             Location c = current.delta(1, 1);
-            if (isPassable.invoke(c)) {
+            if (!isBlocked.invoke(c) && isPassable.invoke(c)) {
                 result.add(c);
             }
         }

--- a/src/hu/openig/mechanics/AI.java
+++ b/src/hu/openig/mechanics/AI.java
@@ -229,12 +229,10 @@ public class AI implements AIManager {
             for (SpacewarStructure s : world.structures(p)) {
                 s.guard |= s.type == StructureType.STATION || s.type == StructureType.PROJECTOR;
                 if (s.type == StructureType.SHIP
-
                         && s.item != null
-
                         && s.item.type.category == ResearchSubCategory.SPACESHIPS_FIGHTERS
                         && s.attackUnit != null && !s.attackUnit.isDestroyed()) {
-                    if (s.count == 1 && s.hp * 10 < s.hpMax) {
+                    if (s.count == 1 && s.hp * 10 < s.hpMax && s.kamikaze == 0) {
                         world.attack(s, s.attackUnit, Mode.KAMIKAZE);
                     }
                 }

--- a/src/hu/openig/mechanics/AIDefaultSpaceBattle.java
+++ b/src/hu/openig/mechanics/AIDefaultSpaceBattle.java
@@ -72,10 +72,11 @@ public class AIDefaultSpaceBattle implements AISpaceBattleManager {
             hpActual += s.hp + Math.max(0, s.shield);
         }
         return Pair.of(hpActual, hpTotal);
-    }    /**
-     * Check if the current set of structures no longer has any weapons.
+    }
+    /**
+     * Check if the current set of structures has any weapons.
      * @param structs the structure list
-     * @return true if the set of structures has no weapons
+     * @return true if the set of structures has weapons
      */
     public boolean haveAnyWeapons(List<SpacewarStructure> structs) {
         for (SpacewarStructure s : structs) {
@@ -91,6 +92,13 @@ public class AIDefaultSpaceBattle implements AISpaceBattleManager {
     public SpacewarAction spaceBattle(List<SpacewarStructure> idles) {
         List<SpacewarStructure> own = world.structures(p);
 
+        if (world.battle().enemyFlee && !world.battle().fleeingBlockedByPlanet(p)) {
+            for (SpacewarStructure s : own) {
+                world.flee(s);
+            }
+            return SpacewarAction.FLEE;
+        }
+
         if (haveAnyWeapons(own)) {
             if (!world.battle().canFlee(p) || !checkFlee(own)) {
                 AI.defaultAttackBehavior(world, idles, p);
@@ -102,13 +110,10 @@ public class AIDefaultSpaceBattle implements AISpaceBattleManager {
             BattleInfo battle = world.battle();
             if (battle.attacker.owner == p) {
                 for (SpacewarStructure s : own) {
-                    if (!s.flee) {
-                        world.flee(s);
-                    }
+                    world.flee(s);
                 }
             }
             battle.enemyFlee = p != p.world.player;
-            return SpacewarAction.FLEE;
         }
         AI.defaultAttackBehavior(world, idles, p);
 

--- a/src/hu/openig/mechanics/AIDefaultSpaceBattle.java
+++ b/src/hu/openig/mechanics/AIDefaultSpaceBattle.java
@@ -102,7 +102,9 @@ public class AIDefaultSpaceBattle implements AISpaceBattleManager {
             BattleInfo battle = world.battle();
             if (battle.attacker.owner == p) {
                 for (SpacewarStructure s : own) {
-                    world.flee(s);
+                    if (!s.flee) {
+                        world.flee(s);
+                    }
                 }
             }
             battle.enemyFlee = p != p.world.player;

--- a/src/hu/openig/mechanics/AIPirate.java
+++ b/src/hu/openig/mechanics/AIPirate.java
@@ -116,9 +116,7 @@ public class AIPirate implements AIManager {
                 AI.defaultAttackBehavior(world, idles, p);
             } else {
                 for (SpacewarStructure s : sts) {
-                    if (!s.flee) {
-                        world.flee(s);
-                    }
+                    world.flee(s);
                 }
                 world.battle().enemyFlee = true;
             }

--- a/src/hu/openig/mechanics/AIPirate.java
+++ b/src/hu/openig/mechanics/AIPirate.java
@@ -116,7 +116,9 @@ public class AIPirate implements AIManager {
                 AI.defaultAttackBehavior(world, idles, p);
             } else {
                 for (SpacewarStructure s : sts) {
-                    world.flee(s);
+                    if (!s.flee) {
+                        world.flee(s);
+                    }
                 }
                 world.battle().enemyFlee = true;
             }

--- a/src/hu/openig/mechanics/AITrader.java
+++ b/src/hu/openig/mechanics/AITrader.java
@@ -42,7 +42,6 @@ import hu.openig.utils.XElement;
 
 import java.awt.Dimension;
 import java.awt.Point;
-import java.awt.geom.Point2D;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -560,7 +559,9 @@ public class AITrader implements AIManager {
             if (fh.first * 4 < initialDefense * 3) {
                 if (!battle.enemyFlee) {
                     for (SpacewarStructure s : sts) {
-                        world.flee(s);
+                        if (!s.flee) {
+                            world.flee(s);
+                        }
                     }
                     battle.enemyFlee = true;
                 }
@@ -583,7 +584,10 @@ public class AITrader implements AIManager {
             }
 
             for (SpacewarStructure s : idles) {
-                s.moveTo = new Point2D.Double(s.x + facing * s.movementSpeed, s.y);
+                if (!s.hasPlannedMove()) {
+                    s.flee = true;
+                    world.move(s, facing * s.movementSpeed, s.y);
+                }
             }
 
             if (battle.showLanding) {

--- a/src/hu/openig/mechanics/AITrader.java
+++ b/src/hu/openig/mechanics/AITrader.java
@@ -33,14 +33,12 @@ import hu.openig.model.ResponseMode;
 import hu.openig.model.SpaceStrengths;
 import hu.openig.model.SpacewarAction;
 import hu.openig.model.SpacewarStructure;
-import hu.openig.model.SpacewarStructure.StructureType;
 import hu.openig.model.SpacewarWorld;
 import hu.openig.model.World;
 import hu.openig.utils.Exceptions;
 import hu.openig.utils.U;
 import hu.openig.utils.XElement;
 
-import java.awt.Dimension;
 import java.awt.Point;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -530,20 +528,7 @@ public class AITrader implements AIManager {
 
                 if (battle.helperPlanet != null && battle.helperPlanet.owner == battle.attacker.owner) {
                     if (lastVisitedPlanet.get(our) == battle.helperPlanet) {
-
                         // flip positions
-
-                        Dimension d = world.space();
-                        for (SpacewarStructure s : world.structures()) {
-                            if (s.type == StructureType.SHIP) {
-                                s.x = d.width - s.x - 100;
-                                if (battle.showLanding && s.owner == player) {
-                                    s.x -= 100;
-                                }
-                                s.angle -= Math.PI;
-                            }
-                        }
-
                         battle.invert = true;
                     }
                 }
@@ -559,13 +544,11 @@ public class AITrader implements AIManager {
             if (fh.first * 4 < initialDefense * 3) {
                 if (!battle.enemyFlee) {
                     for (SpacewarStructure s : sts) {
-                        if (!s.flee) {
-                            world.flee(s);
-                        }
+                        world.flee(s);
                     }
                     battle.enemyFlee = true;
                 }
-                if (battle.showLanding) {
+                if (battle.showLanding && battle.invert) {
                     Point lp = world.landingPlace();
                     for (SpacewarStructure s : sts) {
                         double d1 = lp.distance(s.x, s.y);
@@ -578,21 +561,29 @@ public class AITrader implements AIManager {
             }
             // move a bit forward
             int facing = world.facing();
-
             if (battle.invert) {
                 facing = -facing;
             }
 
-            for (SpacewarStructure s : idles) {
-                if (!s.hasPlannedMove()) {
-                    s.flee = true;
-                    world.move(s, facing * s.movementSpeed, s.y);
+            for (SpacewarStructure s : new ArrayList<>(idles)) {
+                Point lp = world.landingPlace();
+                if (!s.hasPlannedMove() && !battle.enemyFlee) {
+                    if (battle.showLanding && !battle.invert) {
+                        world.move(s, lp.x, lp.y);
+                    } else {
+                        s.flee = true;
+                        world.move(s, Math.max(facing * 150, facing * (world.space().width + 150)), s.y);
+                    }
+                    idles.remove(s);
                 }
             }
 
             if (battle.showLanding) {
                 Point lp = world.landingPlace();
                 for (SpacewarStructure s : sts) {
+                    if (!s.flee) {
+                        world.move(s, lp.x, lp.y);
+                    }
                     double d1 = lp.distance(s.x, s.y);
                     if (d1 <= 5 || s.x >= lp.x) {
                         return SpacewarAction.SURRENDER;

--- a/src/hu/openig/mechanics/FreeFormSpaceWarMovementHandler.java
+++ b/src/hu/openig/mechanics/FreeFormSpaceWarMovementHandler.java
@@ -30,7 +30,7 @@ public class FreeFormSpaceWarMovementHandler extends WarMovementHandler {
     }
 
     @Override
-    public void moveUnit(WarUnit unit) {
+    public boolean moveUnit(WarUnit unit) {
         SpacewarStructure ship = (SpacewarStructure) unit;
         double nextX = ship.getNextMove().x;
         double nextY = ship.getNextMove().y;
@@ -46,8 +46,10 @@ public class FreeFormSpaceWarMovementHandler extends WarMovementHandler {
                 ship.gridX = nextX;
                 ship.gridY = nextY;
                 clearUnitGoal(unit);
+                return true;
             }
         }
+        return false;
     }
 
     @Override

--- a/src/hu/openig/mechanics/FreeFormSpaceWarMovementHandler.java
+++ b/src/hu/openig/mechanics/FreeFormSpaceWarMovementHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2008-present, David Karnok & Contributors
+ * The file is part of the Open Imperium Galactica project.
+ *
+ * The code should be distributed under the LGPL license.
+ * See http://www.gnu.org/licenses/lgpl.html for details.
+ */
+
+package hu.openig.mechanics;
+
+import hu.openig.core.Location;
+import hu.openig.model.SpacewarStructure;
+import hu.openig.model.WarUnit;
+
+/**
+ * Class for a for handling free form movement of space war objects.
+ */
+public class FreeFormSpaceWarMovementHandler extends WarMovementHandler {
+
+    public FreeFormSpaceWarMovementHandler(int cellSize, int simulationDelay) {
+        super(cellSize, simulationDelay);
+    }
+
+    @Override
+    public void removeUnit(WarUnit unit) { }
+    @Override
+    public void setMovementGoal(WarUnit unit, Location loc) {
+        unit.setNextMove(loc);
+        unit.setHasPlannedMove(true);
+    }
+
+    @Override
+    public void moveUnit(WarUnit unit) {
+        SpacewarStructure ship = (SpacewarStructure) unit;
+        double nextX = ship.getNextMove().x;
+        double nextY = ship.getNextMove().y;
+        if (rotateStep(ship, nextX, nextY)) {
+        // travel until the distance
+            double dist = Math.hypot(ship.gridX - nextX, ship.gridY - nextY);
+            double angle = Math.atan2(nextY - ship.gridY, nextX - ship.gridX);
+            double ds = 1.0 * simulationDelay / ship.movementSpeed / cellSize;
+            if (dist > ds) {
+                ship.gridX += ds * Math.cos(angle);
+                ship.gridY += ds * Math.sin(angle);
+            } else {
+                ship.gridX = nextX;
+                ship.gridY = nextY;
+                clearUnitGoal(unit);
+            }
+        }
+    }
+
+    @Override
+    public void clearUnitGoal(WarUnit unit) {
+        unit.getPath().clear();
+        unit.clearNextMove();
+        unit.setHasPlannedMove(false);
+    }
+
+    @Override
+    public void doPathPlannings() { }
+}

--- a/src/hu/openig/mechanics/GroundWarMovementHandler.java
+++ b/src/hu/openig/mechanics/GroundWarMovementHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2008-present, David Karnok & Contributors
+ * The file is part of the Open Imperium Galactica project.
+ *
+ * The code should be distributed under the LGPL license.
+ * See http://www.gnu.org/licenses/lgpl.html for details.
+ */
+
+package hu.openig.mechanics;
+
+import hu.openig.core.Location;
+import hu.openig.model.PlanetSurface;
+import hu.openig.model.WarUnit;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Class for a for handling pathfinding and movement of ground war units.
+ */
+public class GroundWarMovementHandler extends SimpleWarMovementHandler {
+
+    /** Planetary surface placement helper used for finding obstacles. */
+    PlanetSurface.PlacementHelper placement;
+
+    public GroundWarMovementHandler(ScheduledExecutorService commonExecutorPool, int cellSize, int simulationDelay, List<? extends WarUnit> units, int gridSizeX, int gridSizeY, PlanetSurface.PlacementHelper placement) {
+        super(commonExecutorPool, cellSize, simulationDelay, units, gridSizeX, gridSizeY);
+        this.pathWeightMap = new PathWeightMap(gridSizeX + gridSizeY + 3, gridSizeX + gridSizeY + 3, gridSizeY + 1, gridSizeX + gridSizeY + 1);
+        this.pathPlanner = new PathPlanner(commonExecutorPool, pathWeightMap);
+        this.placement = placement;
+    }
+    @Override
+    boolean isBlocked(Location loc, WarUnit unit) {
+        return !placement.canPlaceBuilding(loc.x, loc.y);
+    }
+
+}

--- a/src/hu/openig/mechanics/PathPlanner.java
+++ b/src/hu/openig/mechanics/PathPlanner.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2008-present, David Karnok & Contributors
+ * The file is part of the Open Imperium Galactica project.
+ *
+ * The code should be distributed under the LGPL license.
+ * See http://www.gnu.org/licenses/lgpl.html for details.
+ */
+
+package hu.openig.mechanics;
+
+import hu.openig.core.Location;
+import hu.openig.model.WarUnit;
+import hu.openig.utils.Exceptions;
+
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class PathPlanner {
+
+    /** Plan only the given amount of paths per tick. */
+    static final int PATHS_PER_TICK = 10;
+    /** Common thread pool to use for pathing executions. */
+    ScheduledExecutorService commonExecutorPool;
+    /** A matrix with weighs on individual locations. */
+    PathWeightMap pathWeightMap;
+    /** An ordered map of units:paths planned. */
+    final LinkedHashMap<WarUnit, PathPlanning> pathsToPlan = new LinkedHashMap<>();
+
+    public PathPlanner(ScheduledExecutorService commonExecutorPool, PathWeightMap pathWeightMap) {
+        this.commonExecutorPool = commonExecutorPool;
+        this.pathWeightMap = pathWeightMap;
+
+    }
+
+    public void addPathPlanning(WarUnit unit, Location goal)  {
+        pathsToPlan.put(unit, new PathPlanning(unit, goal, pathWeightMap));
+    }
+    /**
+     * Execute path plannings asynchronously.
+     */
+    public void doPathPlannings() {
+        if (pathsToPlan.size() > 0) {
+
+            // map all units to locations
+//            long t0 = System.nanoTime();
+
+            List<Future<PathPlanning>> inProgress = new LinkedList<>();
+            Iterator<Map.Entry<WarUnit, PathPlanning>> it = pathsToPlan.entrySet().iterator();
+            int i = PATHS_PER_TICK;
+            while (i-- > 0 && it.hasNext()) {
+                Map.Entry<WarUnit, PathPlanning> ppi = it.next();
+                it.remove();
+                inProgress.add(commonExecutorPool.submit(ppi.getValue()));
+            }
+            for (Future<PathPlanning> f : inProgress) {
+                try {
+                    // If failed to find a path, try again, probably blocked by other units
+                    if (f.get().pathFound) {
+                        f.get().apply();
+                    } else {
+                        if (f.get().pathingAttempts > 0) {
+                            pathsToPlan.put(f.get().unit , f.get());
+                        }
+                    }
+                } catch (ExecutionException | InterruptedException ex) {
+                    Exceptions.add(ex);
+                }
+            }
+
+//            t0 = System.nanoTime() - t0;
+//            System.out.printf("Planning %.6f%n", t0 / 1000000000d);
+        }
+    }
+}

--- a/src/hu/openig/mechanics/PathPlanning.java
+++ b/src/hu/openig/mechanics/PathPlanning.java
@@ -53,13 +53,7 @@ public class PathPlanning implements Callable<PathPlanning> {
 
     @Override
     public PathPlanning call() {
-        Pair<Boolean, List<Location>> result;
-        try {
-            result = unit.getPathingMethod().searchApproximate(current, goal);
-        } catch (NullPointerException e) {
-            System.out.println(unit);
-            throw e;
-        }
+        Pair<Boolean, List<Location>> result = unit.getPathingMethod().searchApproximate(current, goal);
         pathingAttempts--;
         if (result.first) {
             pathFound = true;

--- a/src/hu/openig/mechanics/PathPlanning.java
+++ b/src/hu/openig/mechanics/PathPlanning.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2008-present, David Karnok & Contributors
+ * The file is part of the Open Imperium Galactica project.
+ *
+ * The code should be distributed under the LGPL license.
+ * See http://www.gnu.org/licenses/lgpl.html for details.
+ */
+
+package hu.openig.mechanics;
+
+import hu.openig.core.Location;
+import hu.openig.core.Pair;
+import hu.openig.model.WarUnit;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * The task to plan a route to the given destination asynchronously.
+
+ * @author akarnokd, 2011.12.25.
+ */
+public class PathPlanning implements Callable<PathPlanning> {
+    /** The initial location. */
+    final Location current;
+    /** The goal location. */
+    final Location goal;
+    /** The unit. */
+    public final WarUnit unit;
+    /** The computed path. */
+    public boolean pathFound = true;
+    /** A matrix with weighs on individual locations. */
+    PathWeightMap pathWeightMap;
+    /** Number of reattempts after a failed pathing attempt. */
+    public int pathingAttempts = 20;
+    /** The path to merge with. */
+    List<Location> path;
+    /**
+     * Constructor. Initializes the fields.
+     * @param goal the goal location
+     * @param unit the unit
+     */
+    public PathPlanning(WarUnit unit, Location goal, PathWeightMap pathWeightMap) {
+        if (unit.inMotion() && (unit.getNextMove() != null) && (unit.location() != unit.getNextMove())) {
+            this.current = unit.getNextMove();
+        } else {
+            this.current = unit.location();
+        }
+        this.pathWeightMap = pathWeightMap;
+        this.goal = goal;
+        this.unit = unit;
+    }
+
+    @Override
+    public PathPlanning call() {
+        Pair<Boolean, List<Location>> result;
+        try {
+            result = unit.getPathingMethod().searchApproximate(current, goal);
+        } catch (NullPointerException e) {
+            System.out.println(unit);
+            throw e;
+        }
+        pathingAttempts--;
+        if (result.first) {
+            pathFound = true;
+            path = result.second;
+        } else {
+            pathFound = false;
+        }
+        return this;
+    }
+    /**
+     * Apply the computation result.
+     * Increase the weighs on each location that are part of the newly found path.
+     */
+    public void apply() {
+        synchronized (pathWeightMap) {
+            for (Location loc : unit.getPath()) {
+                pathWeightMap.weightMap[loc.x + pathWeightMap.offsetX][loc.y + pathWeightMap.offsetY]--;
+            }
+        }
+        unit.setPath(path);
+        synchronized (pathWeightMap) {
+            for (Location loc : path) {
+                pathWeightMap.weightMap[loc.x + pathWeightMap.offsetX][loc.y + pathWeightMap.offsetY]++;
+            }
+        }
+    }
+    @Override
+    public boolean equals(Object obj) {
+        if (obj != null && obj.getClass() == getClass()) {
+            return unit.equals(((PathPlanning)obj).unit);
+        }
+        return false;
+    }
+    @Override
+    public int hashCode() {
+        return unit.hashCode();
+    }
+}

--- a/src/hu/openig/mechanics/PathWeightMap.java
+++ b/src/hu/openig/mechanics/PathWeightMap.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2008-present, David Karnok & Contributors
+ * The file is part of the Open Imperium Galactica project.
+ *
+ * The code should be distributed under the LGPL license.
+ * See http://www.gnu.org/licenses/lgpl.html for details.
+ */
+
+package hu.openig.mechanics;
+
+public class PathWeightMap {
+
+    /** Matrix to store weighs on cells in a grid. */
+    public short[][] weightMap;
+    /** The width of the weighed a grid. */
+    public int sizeX;
+    /** The height of the weighed a grid. */
+    public int sizeY;
+    /** The width offset to use when lining up the weigh matrix with the underlining grid. */
+    public int offsetX;
+    /** The height offset to use when lining up the weigh matrix with the underlining grid. */
+    public int offsetY;
+
+    public PathWeightMap(int sizeX, int sizeY, int offsetX, int offsetY) {
+        this.sizeX = sizeX;
+        this.sizeY = sizeY;
+        this.offsetX = offsetX;
+        this.offsetY = offsetY;
+        this.weightMap = new short[this.sizeX][this.sizeY];
+    }
+}

--- a/src/hu/openig/mechanics/SimpleSpaceWarMovementHandler.java
+++ b/src/hu/openig/mechanics/SimpleSpaceWarMovementHandler.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2008-present, David Karnok & Contributors
+ * The file is part of the Open Imperium Galactica project.
+ *
+ * The code should be distributed under the LGPL license.
+ * See http://www.gnu.org/licenses/lgpl.html for details.
+ */
+
+package hu.openig.mechanics;
+
+import hu.openig.core.Location;
+import hu.openig.model.SpacewarStructure;
+import hu.openig.model.WarUnit;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Class for handling pathfinding and movement of space war ships.
+ * Simplified with all ships having 1x1 size.
+ */
+public class SimpleSpaceWarMovementHandler extends SimpleWarMovementHandler {
+
+    public SimpleSpaceWarMovementHandler(ScheduledExecutorService commonExecutorPool, int cellSize, int simulationDelay, List<? extends WarUnit> units, int gridSizeX, int gridSizeY) {
+        super(commonExecutorPool, cellSize, simulationDelay, units, gridSizeX, gridSizeY);
+        this.pathWeightMap = new PathWeightMap(gridSizeX + 20, gridSizeY, 10, 0);
+        this.pathPlanner = new PathPlanner(commonExecutorPool, pathWeightMap);
+    }
+    /**
+     * Check if the given cell location fall into the bounds of the battle space.
+     * @param loc location of the cell
+     * @return true if the cell is within the map bounds
+     */
+    public boolean cellInMap(Location loc, WarUnit unit) {
+        if (((SpacewarStructure) unit).flee) {
+            return (loc.y >= 0 && loc.x >= -10 && loc.y <= gridSizeY - 1 && loc.x <= gridSizeX + 9);
+        }
+        return (loc.y >= 0 && loc.x >= 0 && loc.y <= gridSizeY - 1 && loc.x <= gridSizeX - 1);
+    }
+
+    @Override
+    boolean isBlocked(Location loc, WarUnit unit) {
+        return !cellInMap(loc, unit);
+    }
+
+    @Override
+    boolean ignoreObstacles(Location loc, WarUnit unit) {
+        SpacewarStructure sws = (SpacewarStructure) unit;
+        if (sws.kamikaze > 0 && loc.equals(sws.getAttackTarget().location())) {
+            return true;
+        }
+        return super.ignoreObstacles(loc, unit);
+    }
+
+    @Override
+    boolean isPassable(Location loc, WarUnit unit) {
+        SpacewarStructure sws = (SpacewarStructure) unit;
+        if (sws.kamikaze > 0 && loc.equals(sws.getAttackTarget().location())) {
+            return true;
+        } else {
+            return super.isPassable(loc, unit);
+        }
+    }
+}

--- a/src/hu/openig/mechanics/SimpleWarMovementHandler.java
+++ b/src/hu/openig/mechanics/SimpleWarMovementHandler.java
@@ -1,0 +1,368 @@
+/*
+ * Copyright 2008-present, David Karnok & Contributors
+ * The file is part of the Open Imperium Galactica project.
+ *
+ * The code should be distributed under the LGPL license.
+ * See http://www.gnu.org/licenses/lgpl.html for details.
+ */
+
+package hu.openig.mechanics;
+
+import hu.openig.core.Func1;
+import hu.openig.core.Func2;
+import hu.openig.core.Location;
+import hu.openig.core.Pathfinding;
+import hu.openig.model.WarUnit;
+import hu.openig.utils.Exceptions;
+
+import java.util.*;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Abstract base class for handling pathfinding and movement of war units.
+ */
+public abstract class SimpleWarMovementHandler extends WarMovementHandler {
+
+    /** Map for reserved locations. */
+    public final Map<Location, WarUnit> reservedCells = new HashMap<>();
+    /** Helper map for locations occupied by units. */
+    public final Map<Location, Set<WarUnit>> unitsForPathfinding = new HashMap<>();
+    /** A matrix with weighs on individual locations. */
+    public PathWeightMap pathWeightMap;
+    /** The path planner object responsible for handling the executions of new path searches. */
+    PathPlanner pathPlanner;
+    /** The width of the grid walked by units. */
+    int gridSizeX;
+    /** The height of the grid walked by units. */
+    int gridSizeY;
+    /** The war units. */
+    final List<? extends WarUnit> units;
+    abstract boolean isBlocked(Location loc, WarUnit unit);
+    public SimpleWarMovementHandler(ScheduledExecutorService commonExecutorPool, int cellSize, int simulationDelay, List<? extends WarUnit> units, int gridSizeX, int gridSizeY) {
+        super(cellSize, simulationDelay);
+        this.pathPlanner = new PathPlanner(commonExecutorPool, pathWeightMap);
+        this.gridSizeX = gridSizeX;
+        this.gridSizeY = gridSizeY;
+        this.units = units;
+        for (WarUnit wunit : units) {
+            Location pfl = wunit.location();
+            Set<WarUnit> set = unitsForPathfinding.get(pfl);
+            if (set == null) {
+                set = new HashSet<>();
+                unitsForPathfinding.put(pfl, set);
+            }
+            set.add(wunit);
+            wunit.setPathingMethod(getPathfinding(wunit));
+        }
+    }
+    @Override
+    public void setMovementGoal(WarUnit unit, Location loc) {
+        pathPlanner.addPathPlanning(unit, loc);
+    }
+
+    @Override
+    public void doPathPlannings() {
+        pathPlanner.doPathPlannings();
+    }
+
+    @Override
+    public void clearUnitGoal(WarUnit unit) {
+        synchronized (pathWeightMap) {
+            for (Location loc : unit.getPath()) {
+                pathWeightMap.weightMap[loc.x + pathWeightMap.offsetX][loc.y + pathWeightMap.offsetY]--;
+            }
+        }
+        unit.getPath().clear();
+        if (unit.getNextMove() != null && unit.inMotion()) {
+            addToUnitPath(unit, unit.getNextMove());
+        } else {
+            unit.clearNextMove();
+            unit.setHasPlannedMove(false);
+        }
+    }
+    @Override
+    public void moveUnit(WarUnit unit) {
+        if (unit.isDestroyed()) {
+            return;
+        }
+        if (unit.getNextMove() == null) {
+            // I have no better idea when to do an occasional but this seems to work well enough
+            if (Math.random() > 0.90f) {
+                repath(unit);
+                return;
+            }
+            unit.setNextMove(unit.getPath().peekFirst());
+            unit.setNextRotate(unit.getNextMove());
+
+            // is the next move location still passable?
+            if (!ignoreObstacles(unit.getNextMove(), unit) && (!isPassable(unit.getNextMove(), unit) || isCellReserved(unit.getNextMove(), unit))) {
+                // trigger replanning
+                repath(unit);
+                return;
+            }
+        }
+
+        if (!ignoreObstacles(unit.getNextMove(), unit) && unitsForPathfinding.get(unit.getNextMove()) != null) {
+            for (WarUnit wunit : unitsForPathfinding.get(unit.getNextMove())) {
+                if (wunit != unit && !wunit.inMotion() && !needsRotation(wunit, wunit.getNextRotate())) {
+                    repath(unit);
+                    return;
+                }
+            }
+        }
+
+        if (unit.getNextRotate() != null && rotateStep(unit, unit.getNextRotate().x, unit.getNextRotate().y)) {
+            unit.setNextRotate(null);
+        }
+        if (unit.getNextRotate() == null) {
+            moveUnitStep(unit, simulationDelay);
+        }
+    }
+
+    /**
+     * Move the war unit one step.
+     * @param unit the unit
+     * @param time the available time
+     */
+    void moveUnitStep(WarUnit unit, double time) {
+        double dv = 1.0 * time / unit.getMovementSpeed() / cellSize;
+        // detect collision
+        if (!ignoreObstacles(unit.getNextMove(), unit) && !reserveCellFor(unit)) {
+            return;
+        }
+        double distanceToTarget = Math.hypot(unit.getNextMove().x - unit.exactLocation().x, unit.getNextMove().y - unit.exactLocation().y);
+
+        if (distanceToTarget < dv) {
+            releaseCellFrom(unit);
+
+            updateUnitLocation(unit, unit.getNextMove().x, unit.getNextMove().y, false);
+
+            unit.clearNextMove();
+            removeFirstFromUnitPath(unit);
+            double remaining = dv - distanceToTarget;
+            if (unit.hasPlannedMove()) {
+                Location nextCell = unit.getPath().peekFirst();
+                if (!needsRotation(unit, nextCell)) {
+                    double time2 = remaining * unit.getMovementSpeed() * cellSize;
+                    unit.setNextMove(nextCell);
+                    moveUnitStep(unit, time2);
+                }
+            }
+        } else {
+            double angle = Math.atan2(unit.getNextMove().y - unit.exactLocation().y, unit.getNextMove().x - unit.exactLocation().x);
+            updateUnitLocation(unit, dv * Math.cos(angle), dv * Math.sin(angle), true);
+        }
+    }
+    /**
+     * Reserve the next movement cell for the war unit.
+     * @param unit the unit
+     * @return true if the next cell is successfully reserved
+     */
+    boolean reserveCellFor(WarUnit unit) {
+        if (unitsForPathfinding.get(unit.getNextMove()) != null) {
+            for (WarUnit wunit : unitsForPathfinding.get(unit.getNextMove())) {
+                if (wunit != unit) {
+                    return false;
+                }
+            }
+        } else if (isCellReserved(unit.getNextMove(), unit)) {
+            return false;
+        }
+        reservedCells.put(unit.getNextMove(), unit);
+        return true;
+    }
+
+    /**
+     * Release the reserved movement cell from the war unit.
+     * @param unit the unit
+     */
+    void releaseCellFrom(WarUnit unit) {
+        // remove cell reservation
+        for (Iterator<Map.Entry<Location, WarUnit>> it = reservedCells.entrySet().iterator(); it.hasNext();) {
+            Map.Entry<Location, WarUnit> entry = it.next();
+            if (entry.getValue() == unit) {
+                it.remove();
+            }
+        }
+    }
+    /**
+     * Check if a cell is available for a war unit.
+     * @param loc the location to check
+     * @param unit the unit
+     * @return true if the cell is already reserved
+     */
+    boolean isCellReserved(Location loc, WarUnit unit) {
+        return reservedCells.get(loc) != null &&  reservedCells.get(loc) != unit;
+    }
+
+    /**
+     * Returns a preset pathfinding object.
+     * @param unit the unit doing the pathfinding
+     * @return the pathfinding object
+     */
+    Pathfinding getPathfinding(final WarUnit unit) {
+        Pathfinding pathfinding = new Pathfinding();
+        pathfinding.isPassable = new Func1<Location, Boolean>() {
+            @Override
+            public Boolean invoke(Location value) {
+                return isPassable(value, unit);
+            }
+        };
+        pathfinding.isBlocked = new Func1<Location, Boolean>() {
+            @Override
+            public Boolean invoke(Location value) {
+                return isBlocked(value, unit);
+            }
+        };
+        pathfinding.distance = pathingDistance;
+        return pathfinding;
+    }
+
+    /** Routine that tells the distance between two neighboring locations. */
+    final Func2<Location, Location, Integer> pathingDistance = new Func2<Location, Location, Integer>() {
+        @Override
+        public Integer invoke(Location t, Location u) {
+            double multiplier = 1.0;
+            multiplier += pathWeightMap.weightMap[t.x + pathWeightMap.offsetX][t.y + pathWeightMap.offsetY] * 0.05;
+
+            if (t.x == u.x || u.y == t.y) {
+                return (int) (1000 * multiplier);
+            }
+            return (int)(1414 * multiplier);
+        }
+    };
+    @Override
+    public void removeUnit(WarUnit unit) {
+        // remove from pathfinding helper
+        Location pfl = unit.location();
+        Set<WarUnit> set = unitsForPathfinding.get(pfl);
+        if (set != null) {
+            if (!set.remove(unit)) {
+                Exceptions.add(new AssertionError(String.format("Unit was not found at location %s, %s%n", pfl.x, pfl.y)));
+            }
+        }
+        clearUnitGoal(unit);
+        releaseCellFrom(unit);
+    }
+
+    /**
+     * Update the location of the specified unit by the given amount.
+     * @param unit the unit to move
+     * @param dx the delta X to move
+     * @param dy the delta Y to move
+     * @param relative is this a relative move
+     */
+    void updateUnitLocation(WarUnit unit, double dx, double dy, boolean relative) {
+        Location currentLocation = unit.location();
+        if (relative) {
+            unit.setLocation(unit.exactLocation().x + dx, unit.exactLocation().y + dy);
+        } else {
+            unit.setLocation(dx, dy);
+        }
+        Location nextLocation = unit.location();
+
+        if (!currentLocation.equals(nextLocation)) {
+            // remove from pathfinding helper
+            Set<WarUnit> set = unitsForPathfinding.get(currentLocation);
+            if (set != null) {
+                if (!set.remove(unit)) {
+                    Exceptions.add(new AssertionError(String.format("Unit was not found at location %s, %s%n", currentLocation.x, currentLocation.y)));
+                }
+                if (set.isEmpty()) {
+                    unitsForPathfinding.remove(currentLocation);
+                }
+            }
+        }
+
+        Set<WarUnit> set = unitsForPathfinding.get(nextLocation);
+        if (set == null) {
+            set = new HashSet<>();
+            unitsForPathfinding.put(nextLocation, set);
+        }
+        set.add(unit);
+    }
+
+    /**
+     * Check if the given cell is passable.
+     * Other units are ignore in case they are friendly and in motion
+     * or enemy in case of attackmove.
+     * @param loc the target cell.
+     * @param unit the unit checking the cell.
+     * @return true if the place is passable
+     */
+    boolean isPassable(Location loc, WarUnit unit) {
+            Set<WarUnit> wunits = unitsForPathfinding.get(loc);
+            if (loc.equals(unit.location())) {
+                return true;
+            }
+            if (ignoreObstacles(loc, unit)) {
+                return true;
+            }
+            if (wunits == null) {
+                return true;
+            }
+            if (wunits.isEmpty()) {
+                return true;
+            }
+            boolean ip = false;
+            for (WarUnit u : wunits) {
+                ip = ((u.owner() != unit.owner()) && (unit.attackMoveLocation() != null))
+                        || ((u.owner() == unit.owner()) && (u.inMotion() || needsRotation(u, u.getNextMove())))
+                        || u.equals(unit)
+                        || u.isDestroyed();
+            }
+            return ip;
+    }
+
+    /**
+     * Plan a new route to the current destination.
+     * @param u the unit.
+     */
+    void repath(final WarUnit u) {
+        if (u.getPath().size() >= 1) {
+            final Location goal = u.getPath().peekLast();
+            clearUnitGoal(u);
+            u.clearNextMove();
+            u.clearNextRotate();
+            pathPlanner.addPathPlanning(u, goal);
+        }
+    }
+
+    /**
+     * Check if pathfinding restrictions can be ignored in a location.
+     * @param loc the location to ignore.
+     * @param unit the unit.
+     * @return true if all obstacles can be ignored on the location
+     */
+    boolean ignoreObstacles(Location loc, WarUnit unit) {
+        // If somehow got into this situation where it's own location is impassable
+        if (loc.equals(unit.location())) {
+            return true;
+        }
+        return false;
+    }
+    /**
+     * Add an extra location to the unit's planned path.
+     * @param unit the unit.
+     * @param loc the location to add to unit path.
+     */
+    protected void addToUnitPath(WarUnit unit, Location loc) {
+        synchronized (pathWeightMap) {
+            pathWeightMap.weightMap[loc.x + pathWeightMap.offsetX][loc.y + pathWeightMap.offsetY]++;
+        }
+        unit.getPath().add(loc);
+    }
+    /**
+     * Remove the first location in the unit's planned path.
+     * @param unit the unit.
+     */
+    protected void removeFirstFromUnitPath(WarUnit unit) {
+        Location loc = unit.getPath().removeFirst();
+        synchronized (pathWeightMap) {
+            pathWeightMap.weightMap[loc.x + pathWeightMap.offsetX][loc.y + pathWeightMap.offsetY]--;
+        }
+        if (unit.getPath().isEmpty()) {
+            unit.setHasPlannedMove(false);
+        }
+    }
+}

--- a/src/hu/openig/mechanics/WarMovementHandler.java
+++ b/src/hu/openig/mechanics/WarMovementHandler.java
@@ -39,8 +39,9 @@ public abstract class WarMovementHandler {
     public abstract void setMovementGoal(WarUnit unit, Location loc);
     /** Move a handled unit by one step.
      * @param unit the unit to move
+     * @return the unit finished it's planned movement
      * */
-    public abstract void moveUnit(WarUnit unit);
+    public abstract boolean moveUnit(WarUnit unit);
     /** Clear the movement goal of a unit handled by this object.
      * @param unit the unit to move
      * */

--- a/src/hu/openig/mechanics/WarMovementHandler.java
+++ b/src/hu/openig/mechanics/WarMovementHandler.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2008-present, David Karnok & Contributors
+ * The file is part of the Open Imperium Galactica project.
+ *
+ * The code should be distributed under the LGPL license.
+ * See http://www.gnu.org/licenses/lgpl.html for details.
+ */
+
+package hu.openig.mechanics;
+
+import hu.openig.core.Location;
+import hu.openig.model.WarUnit;
+import hu.openig.utils.U;
+
+
+/**
+ * Abstract base class for handling movement of war units.
+ */
+public abstract class WarMovementHandler {
+
+    /** The size of a cell in pixels. */
+    final int cellSize;
+    /** The simulation delay on normal speed. */
+    int simulationDelay;
+
+
+    WarMovementHandler(int cellSize, int simulationDelay) {
+        this.cellSize = cellSize;
+        this.simulationDelay = simulationDelay;
+    }
+    /** Remove a unit handled by the movement handler object.
+     * @param unit the unit to remove
+     * */
+    public abstract void removeUnit(WarUnit unit);
+    /** Set new movement goal for a unit.
+     * @param unit the unit to move
+     * @param loc the target location
+     * */
+    public abstract void setMovementGoal(WarUnit unit, Location loc);
+    /** Move a handled unit by one step.
+     * @param unit the unit to move
+     * */
+    public abstract void moveUnit(WarUnit unit);
+    /** Clear the movement goal of a unit handled by this object.
+     * @param unit the unit to move
+     * */
+    public abstract void clearUnitGoal(WarUnit unit);
+
+    /** Execute path plannings for that handled units. */
+    public abstract void doPathPlannings();
+
+    /**
+     * Rotate the unit towards the given target angle by a step.
+     * @param unit the war unit
+     * @param targetX x coordinate of the target location
+     * @param targetY y coordinate of the target location
+     * @return rotation done?
+     */
+    public boolean rotateStep(WarUnit unit, double targetX, double targetY) {
+        RotationAngles ra = computeRotation(unit, targetX, targetY);
+
+        double anglePerStep = 2 * Math.PI * unit.getRotationTime() / unit.getAngleCount() / simulationDelay;
+        if (Math.abs(ra.diff) < anglePerStep) {
+            unit.setAngle(ra.targetAngle);
+            return true;
+        }
+        unit.increaseAngle(Math.signum(ra.diff) * anglePerStep);
+        return false;
+    }
+    /**
+     * Checks if the given target location requires the unit to rotate before move.
+     * @param unit the unit
+     * @param target the target location
+     * @return true if rotation is needed
+     */
+    public static boolean needsRotation(WarUnit unit, Location target) {
+        return needsRotation(unit, target, 0);
+    }
+
+    /**
+     * Checks if the given target location requires the unit to rotate before move.
+     * @param unit the unit
+     * @param target the target location
+     * @param tolerance the tolerated angle difference of the rotation in radians
+     * @return true if rotation is needed
+     */
+    public static boolean needsRotation(WarUnit unit, Location target, double tolerance) {
+        if (target == null) {
+            return false;
+        }
+        RotationAngles ra = computeRotation(unit, target.x, target.y);
+        return Math.abs(ra.diff) > tolerance;
+    }
+
+    /**
+     * Computes the rotation angles.
+     * @param unit the unit
+     * @param targetX the target X coordinate
+     * @param targetY the target Y coordinate
+     * @return the angles
+     */
+    static RotationAngles computeRotation(WarUnit unit, double targetX, double targetY) {
+        RotationAngles result = new RotationAngles();
+
+        if (targetY - unit.exactLocation().y == 0 && targetX - unit.exactLocation().x == 0) {
+            result.targetAngle = U.normalizedAngle(unit.getAngle());
+            result.currentAngle = result.targetAngle;
+            result.diff = 0;
+        } else {
+            result.targetAngle = Math.atan2(targetY - unit.exactLocation().y, targetX - unit.exactLocation().x);
+
+            result.currentAngle = U.normalizedAngle(unit.getAngle());
+
+            result.diff = result.targetAngle - result.currentAngle;
+            if (result.diff < -Math.PI) {
+                result.diff += 2 * Math.PI;
+            } else
+            if (result.diff > Math.PI) {
+                result.diff -= 2 * Math.PI;
+
+            }
+        }
+
+        return result;
+    }
+
+    /** The composite record to return the rotation angles. */
+    static class RotationAngles {
+        /** The unit's current angle. */
+        double currentAngle;
+        /** The target angle. */
+        double targetAngle;
+        /** The difference to turn. */
+        double diff;
+    }
+}

--- a/src/hu/openig/model/BattleInfo.java
+++ b/src/hu/openig/model/BattleInfo.java
@@ -308,4 +308,14 @@ public class BattleInfo {
         }
         return false;
     }
+
+    /**
+     * Returns true if the particular player can flee from battle.
+     * @param p the player to check
+     * @return true if flee is allowed
+     */
+    public boolean fleeingBlockedByPlanet(Player p) {
+        return helperPlanet != null && helperPlanet.owner == p;
+    }
+
 }

--- a/src/hu/openig/model/Building.java
+++ b/src/hu/openig/model/Building.java
@@ -9,6 +9,7 @@
 package hu.openig.model;
 
 import hu.openig.core.Location;
+import hu.openig.utils.Exceptions;
 
 import java.awt.Point;
 import java.awt.Rectangle;
@@ -312,6 +313,12 @@ public class Building implements HasLocation {
     public Location location() {
         return location;
     }
+
+    @Override
+    public void setLocation(double x, double y) {
+        Exceptions.add(new AssertionError(String.format("Building location is final. Building: %s", this)));
+    }
+
     /**
      * Returns the bounding rectangle of this building (without offset).
      * @return the bounding rectangle

--- a/src/hu/openig/model/Configuration.java
+++ b/src/hu/openig/model/Configuration.java
@@ -278,6 +278,10 @@ public class Configuration {
     @LoadSave
     @LoadSaveGame
     public boolean buildingTextBackgrounds = true;
+    /** Allow free form movement in spacewar battles. */
+    @LoadSave
+    @LoadSaveGame
+    public boolean spacewarFreeformMovement = false;
     /** The current profile. */
     @LoadSave
     public String currentProfile = "default";

--- a/src/hu/openig/model/GroundwarManager.java
+++ b/src/hu/openig/model/GroundwarManager.java
@@ -1335,7 +1335,7 @@ public class GroundwarManager implements GroundwarWorld {
         Point pg = gun.center();
         double targetAngle = Math.atan2(target.y - pg.y, target.x - pg.x);
 
-        double currentAngle = gun.normalizedAngle();
+        double currentAngle = U.normalizedAngle(gun.angle);
 
         double diff = targetAngle - currentAngle;
         if (diff < -Math.PI) {
@@ -1424,13 +1424,13 @@ public class GroundwarManager implements GroundwarWorld {
         Point pg = u.center();
         Point tg = planet.surface.center(target);
         if (tg.y - pg.y == 0 && tg.x - pg.x == 0) {
-            result.targetAngle = u.normalizedAngle();
+            result.targetAngle = U.normalizedAngle(u.angle);
             result.currentAngle = result.targetAngle;
             result.diff = 0;
         } else {
             result.targetAngle = Math.atan2(tg.y - pg.y, tg.x - pg.x);
 
-            result.currentAngle = u.normalizedAngle();
+            result.currentAngle = U.normalizedAngle(u.angle);
 
             result.diff = result.targetAngle - result.currentAngle;
             if (result.diff < -Math.PI) {

--- a/src/hu/openig/model/GroundwarManager.java
+++ b/src/hu/openig/model/GroundwarManager.java
@@ -492,7 +492,7 @@ public class GroundwarManager implements GroundwarWorld {
             if (u.owner != owner) {
                 if (U.cellInRange(cx, cy, u.x, u.y, area)) {
                     if (!u.isDestroyed()) {
-                        u.damage((int)(damage * (area - Math.hypot(cx - u.x, cy - u.y)) / area));
+                        u.applyDamage((int)(damage * (area - Math.hypot(cx - u.x, cy - u.y)) / area));
                         if (u.isDestroyed()) {
                             createExplosion(u, ExplosionType.GROUND_RED);
 
@@ -1223,7 +1223,7 @@ public class GroundwarManager implements GroundwarWorld {
         } else
         if (unitWithinRange(u, u.attackUnit)) {
             if (!u.attackUnit.isDestroyed()) {
-                u.attackUnit.damage(u.damage());
+                u.attackUnit.applyDamage(u.damage());
                 if (u.attackUnit.isDestroyed()) {
                     playSounds.add(u.attackUnit.model.destroy);
                     createExplosion(u.attackUnit, ExplosionType.GROUND_RED);
@@ -1273,7 +1273,7 @@ public class GroundwarManager implements GroundwarWorld {
 
                         && g.inRange(g.attack)) {
                     if (!g.attack.isDestroyed()) {
-                        g.attack.damage(g.damage());
+                        g.attack.applyDamage(g.damage());
                         if (g.attack.isDestroyed()) {
                             playSounds.add(g.attack.model.destroy);
                             createExplosion(g.attack, ExplosionType.GROUND_RED);

--- a/src/hu/openig/model/GroundwarObject.java
+++ b/src/hu/openig/model/GroundwarObject.java
@@ -8,6 +8,8 @@
 
 package hu.openig.model;
 
+import hu.openig.utils.U;
+
 import java.awt.image.BufferedImage;
 
 /**
@@ -37,12 +39,18 @@ public abstract class GroundwarObject {
         this.matrix = matrix;
         this.angles = computeAngles(matrix[0].length);
     }
+
     /** @return Get the image for the current rotation and phase. */
     public BufferedImage get() {
+        return getImageForAngle(U.normalizedAngle(angle));
+    }
+
+    /** @return Get the image for the current rotation and phase. */
+    protected BufferedImage getImageForAngle(double objectAngle) {
         BufferedImage[] rotation = matrix[fireAnimPhase % matrix.length];
 
         if (cachedAngle != angle) {
-            double a = normalizedAngle() / 2 / Math.PI;
+            double a = objectAngle / 2 / Math.PI;
             if (a < 0) {
                 a = 1 + a;
             }
@@ -72,12 +80,6 @@ public abstract class GroundwarObject {
             cachedAngle = angle;
         }
         return rotation[cachedIndex % rotation.length];
-    }
-    /**
-     * @return the normalized angle between -PI and +PI.
-     */
-    public double normalizedAngle() {
-        return Math.atan2(Math.sin(angle), Math.cos(angle));
     }
     /**
      * @return the maximum phase index

--- a/src/hu/openig/model/GroundwarUnit.java
+++ b/src/hu/openig/model/GroundwarUnit.java
@@ -125,7 +125,7 @@ public class GroundwarUnit extends GroundwarObject implements WarUnit {
      * Apply damage to this unit.
      * @param points the points of damage
      */
-    public void damage(double points) {
+    public void applyDamage(double points) {
         hp = Math.max(0, hp - points);
     }
     /**

--- a/src/hu/openig/model/GroundwarUnit.java
+++ b/src/hu/openig/model/GroundwarUnit.java
@@ -9,12 +9,12 @@
 package hu.openig.model;
 
 import hu.openig.core.Location;
+import hu.openig.core.Pathfinding;
 import hu.openig.utils.U;
 
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.geom.Point2D;
-import java.awt.geom.Point2D.Double;
 import java.awt.image.BufferedImage;
 import java.util.Comparator;
 import java.util.LinkedList;
@@ -39,16 +39,18 @@ public class GroundwarUnit extends GroundwarObject implements WarUnit {
     public double hp;
     /** The original inventory item. */
     public InventoryItem item;
-    /** Unit target if non null. */
+    /** Unit target if non-null. */
     public GroundwarUnit attackUnit;
-    /** Building target if non null. */
+    /** Building target if non-null. */
     public Building attackBuilding;
-    /** The target of the attack-move if non null. */
+    /** The target of the attack-move if non-null. */
     public Location attackMove;
     /** The weapon cooldown counter. */
     public int cooldown;
     /** The current movement path to the target. */
-    public final LinkedList<Location> path = new LinkedList<>();
+    public LinkedList<Location> path = new LinkedList<>();
+    /** Pathfinding object used by the unit.*/
+    public Pathfinding pathfinding;
     /** The next move rotation. */
     public Location nextRotate;
     /** The next move location. */
@@ -69,6 +71,8 @@ public class GroundwarUnit extends GroundwarObject implements WarUnit {
     public boolean guard = true;
     /** Is the unit selected? */
     public boolean selected;
+    /** The unit has movement plans. */
+    public boolean hasPlannedMove = false;
     /**
      * Orders the units based on damage level.
      */
@@ -78,9 +82,44 @@ public class GroundwarUnit extends GroundwarObject implements WarUnit {
             return java.lang.Double.compare(o1.hp / o1.model.hp, o2.hp / o2.model.hp);
         }
     };
+
+    @Override
+    public boolean hasPlannedMove() {
+        return hasPlannedMove;
+    }
+
+    @Override
+    public void setHasPlannedMove(boolean hasPlannedMove) {
+        this.hasPlannedMove = hasPlannedMove;
+    }
+
     /** @return is this unit destroyed? */
     public boolean isDestroyed() {
         return hp <= 0;
+    }
+    @Override
+    public void setAngle(double angle) {
+        this.angle = angle;
+    }
+    @Override
+    public double getAngle() {
+        return this.angle;
+    }
+    @Override
+    public void increaseAngle(double angle) {
+        this.angle += angle;
+    }
+    @Override
+    public int getAngleCount() {
+        return angles.length;
+    }
+    @Override
+    public int getRotationTime() {
+        return model.rotationTime;
+    }
+    @Override
+    public int getMovementSpeed() {
+        return model.movementSpeed;
     }
     /**
      * Apply damage to this unit.
@@ -102,7 +141,12 @@ public class GroundwarUnit extends GroundwarObject implements WarUnit {
         return Location.of((int)Math.round(x), (int)Math.round(y));
     }
     @Override
-    public Double exactLocation() {
+    public void setLocation(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+    @Override
+    public Point2D.Double exactLocation() {
         return new Point2D.Double(x, y);
     }
     @Override
@@ -114,12 +158,28 @@ public class GroundwarUnit extends GroundwarObject implements WarUnit {
         return attackMove;
     }
     @Override
-    public Location nextMove() {
+    public Location getNextMove() {
         return nextMove;
     }
     @Override
-    public Location nextRotate() {
+    public void setNextMove(Location nextMove) {
+        this.nextMove = nextMove;
+    }
+    @Override
+    public void clearNextMove() {
+        this.nextMove = null;
+    }
+    @Override
+    public Location getNextRotate() {
         return nextRotate;
+    }
+    @Override
+    public void setNextRotate(Location nextRotate) {
+        this.nextRotate = nextRotate;
+    }
+    @Override
+    public void clearNextRotate() {
+        this.nextRotate = null;
     }
     @Override
     public String toString() {
@@ -157,12 +217,16 @@ public class GroundwarUnit extends GroundwarObject implements WarUnit {
     /** @return true if the unit is moving. */
     @Override
     public boolean isMoving() {
-        return nextMove != null || !path.isEmpty();
+        return nextMove != null || hasPlannedMove;
     }
     /** @return true if the unit is in between cells. */
     @Override
     public boolean inMotion()  {
         return (x % 1 != 0) || (y % 1 != 0);
+    }
+    @Override
+    public LinkedList<Location> getPath() {
+        return path;
     }
     /**
      * @return the target cell of movement or null if not moving
@@ -264,12 +328,36 @@ public class GroundwarUnit extends GroundwarObject implements WarUnit {
         return new Point(px + model.width / 2, py + model.height / 2);
     }
     /**
+     * @return the isometric angle used for rendering.
+     */
+    public double isometricAngle() {
+        double angle = U.normalizedAngle(this.angle + 0.733038);
+        if (((Math.PI / 2) > angle) && (-(Math.PI / 2) < angle)) {
+            return Math.atan(Math.tan(-angle) / 2);
+        } else {
+            return Math.atan(Math.tan(-angle) / 2) + Math.PI;
+        }
+    }
+    @Override
+    public BufferedImage get() {
+        return getImageForAngle(isometricAngle());
+    }
+    @Override
+    public Pathfinding getPathingMethod() {
+        return pathfinding;
+    }
+    @Override
+    public void setPathingMethod(Pathfinding pathfinding) {
+        this.pathfinding = pathfinding;
+    }
+    /**
      * Merges the new path.
      * @param newPath the new path to follow
      */
     @Override
-    public void mergePath(List<Location> newPath) {
+    public void setPath(List<Location> newPath) {
         path.clear();
         path.addAll(newPath);
+        hasPlannedMove = true;
     }
 }

--- a/src/hu/openig/model/HasLocation.java
+++ b/src/hu/openig/model/HasLocation.java
@@ -20,6 +20,10 @@ public interface HasLocation {
     /** @return the exact fractional location. */
     Point2D.Double exactLocation();
     /** @return the integral location. */
-
     Location location();
+    /** Set new location.
+     *  @param x the x coordinate
+     *  @param y the x coordinate
+     */
+    void setLocation(double x, double y);
 }

--- a/src/hu/openig/model/SpacewarObject.java
+++ b/src/hu/openig/model/SpacewarObject.java
@@ -20,6 +20,10 @@ public abstract class SpacewarObject {
     public double x;
     /** The current location. */
     public double y;
+    /** The position with fractional precision in grid coordinates. */
+    public double gridX;
+    /** The position with fractional precision in grid coordinates. */
+    public double gridY;
     /** The owner player. */
     public Player owner;
     /**
@@ -56,6 +60,8 @@ public abstract class SpacewarObject {
         int h = other.get().getHeight();
         return intersects(other.x - (w / 2d), other.y - (h / 2d), w , h);
     }
+    /** The object angle in an X-Y screen directed coordinate system. */
+    public double angle;
     /**
      * Test if the object is completely within the specified bounds.
      * @param rx the rectangle left

--- a/src/hu/openig/model/SpacewarProjectile.java
+++ b/src/hu/openig/model/SpacewarProjectile.java
@@ -8,6 +8,8 @@
 
 package hu.openig.model;
 
+import hu.openig.utils.U;
+
 import java.awt.image.BufferedImage;
 import java.util.Objects;
 
@@ -31,8 +33,6 @@ public class SpacewarProjectile extends SpacewarObject {
     public int ecmLimit;
     /** The damage to inflict. */
     public double damage;
-    /** The beam angle in an X-Y screen directed coordinate system, 0..2*PI. */
-    public double angle;
     /** The source of this projectile. */
     public SpacewarStructure source;
     /** The targeted structure. */
@@ -49,7 +49,7 @@ public class SpacewarProjectile extends SpacewarObject {
     @Override
     public BufferedImage get() {
         // -0.5 .. +0.5
-        double a = normalizedAngle() / Math.PI / 2;
+        double a = U.normalizedAngle(angle) / Math.PI / 2;
         if (a < 0) {
             a = 1 + a;
 
@@ -58,11 +58,5 @@ public class SpacewarProjectile extends SpacewarObject {
         BufferedImage[] imageAngle = matrix[phaseIndex];
         int angleIndex = ((int)Math.round(imageAngle.length * a)) % imageAngle.length;
         return imageAngle[angleIndex];
-    }
-    /**
-     * @return the normalized angle between -PI and +PI.
-     */
-    public double normalizedAngle() {
-        return Math.atan2(Math.sin(angle), Math.cos(angle));
     }
 }

--- a/src/hu/openig/model/SpacewarStructure.java
+++ b/src/hu/openig/model/SpacewarStructure.java
@@ -450,7 +450,7 @@ public class SpacewarStructure extends SpacewarObject implements WarUnit {
     @Override
     public String toString() {
         return String.format("Type = %s, Count = %s, Owner = %s, HP = %s, Shield = %s, Parent = %s"
-                , type, count, owner.id, hp, shield, (fleet != null ? fleet.name() : (planet != null ? planet.id : "")));
+                , item.type.category, count, owner.id, hp, shield, (fleet != null ? fleet.name() : (planet != null ? planet.id : "")));
     }
     /**
      * @return checks if this structure has direct fire capability with a beam weapon.

--- a/src/hu/openig/model/SpacewarWorld.java
+++ b/src/hu/openig/model/SpacewarWorld.java
@@ -33,6 +33,11 @@ public interface SpacewarWorld {
      */
     List<SpacewarStructure> structures(Player owner);
     /**
+     * Remove a structure from the battle.
+     * @param sws the structure to remove
+     */
+     void removeStructure(SpacewarStructure sws);
+    /**
      * Returns the list of enemies to the structure.
      * @param s the structure
 

--- a/src/hu/openig/model/WarUnit.java
+++ b/src/hu/openig/model/WarUnit.java
@@ -10,7 +10,9 @@ package hu.openig.model;
 
 
 import hu.openig.core.Location;
+import hu.openig.core.Pathfinding;
 
+import java.util.LinkedList;
 import java.util.List;
 
 /**
@@ -18,21 +20,40 @@ import java.util.List;
  */
 public interface WarUnit extends HasLocation, Owned {
 
+    /** @return true if the unit has planned moves. */
+    boolean hasPlannedMove();
+    void setHasPlannedMove(boolean hasPlannedMove);
+    /** @return true if the is destroyed. */
+    boolean isDestroyed();
+    void setAngle(double angle);
+    double getAngle();
+    void increaseAngle(double angle);
+    int getAngleCount();
+    int getRotationTime();
+    int getMovementSpeed();
     /** @return the attack target of the WarUnit. */
     WarUnit getAttackTarget();
     /** @return attack move location of the WarUnit. */
     Location attackMoveLocation();
     /** @return next movement target location in the path of the WarUnit. */
-    Location nextMove();
+    Location getNextMove();
+    void setNextMove(Location nextMove);
+    void clearNextMove();
     /** @return next rotation target location of the WarUnit. */
-    Location nextRotate();
+    Location getNextRotate();
+    void setNextRotate(Location nextRotate);
+    void clearNextRotate();
     /** @return true if the unit is moving. */
      boolean isMoving();
     /** @return true if the unit is in between cells. */
     boolean inMotion();
+    LinkedList<Location> getPath();
+
+    void setPathingMethod(Pathfinding pathing);
+    Pathfinding getPathingMethod();
     /**
      * Merges the new path.
      * @param newPath the new path to follow
      */
-    void mergePath(List<Location> newPath);
+    void setPath(List<Location> newPath);
 }

--- a/src/hu/openig/screen/items/LoadSaveScreen.java
+++ b/src/hu/openig/screen/items/LoadSaveScreen.java
@@ -817,6 +817,8 @@ public class LoadSaveScreen extends ScreenBase implements LoadSaveScreenAPI {
         UICheckBox continuousMoney;
         /** Automatically display objectives on change. */
         UICheckBox autoDisplayObjectives;
+        /** Use freeform movement in spacewar battles. */
+        UICheckBox freeformSpacewarMovement;
 
         void init() {
             reequipTanks = new UICheckBox(get("settings.reequip_tanks"), 14, commons.common().checkmark, commons.text());
@@ -887,6 +889,16 @@ public class LoadSaveScreen extends ScreenBase implements LoadSaveScreenAPI {
                     config.autoRepair = autoRepair.selected();
                 }
             };
+
+            freeformSpacewarMovement = new UICheckBox(get("settings.freeform_movement"), 14, commons.common().checkmark, commons.text());
+            freeformSpacewarMovement.onChange = new Action0() {
+                @Override
+                public void invoke() {
+                    buttonSound(SoundType.CLICK_MEDIUM_2);
+                    config.spacewarFreeformMovement = freeformSpacewarMovement.selected();
+                }
+            };
+
 
             final UIImageButton rmprev = new UIImageButton(commons.common().moveLeft);
             rmprev.setDisabledPattern(commons.common().disabledPattern);
@@ -1058,6 +1070,7 @@ public class LoadSaveScreen extends ScreenBase implements LoadSaveScreenAPI {
                     return format("settings.base_speed_value", config.timestep);
                 }
             };
+            freeformSpacewarMovement.selected(config.spacewarFreeformMovement);
             reequipTanks.selected(config.reequipTanks);
             reequipBombs.selected(config.reequipBombs);
             targetSpecificRockets.selected(config.targetSpecificRockets);
@@ -1094,7 +1107,8 @@ public class LoadSaveScreen extends ScreenBase implements LoadSaveScreenAPI {
         int setComponentLocations() {
             int dy = 5;
             int ddy = 30;
-
+            freeformSpacewarMovement.location(10, dy + 8);
+            dy += ddy;
             reequipTanks.location(10, dy + 8);
             dy += ddy;
             reequipBombs.location(10, dy + 8);

--- a/src/hu/openig/scripting/missions/Mission14.java
+++ b/src/hu/openig/scripting/missions/Mission14.java
@@ -83,7 +83,8 @@ public class Mission14 extends Mission {
                 && (bi.targetFleet != null && hasTag(bi.targetFleet, "Mission-14-Garthog"))) {
             Player garthog = player("Garthog");
             for (SpacewarStructure s : war.structures(garthog)) {
-                war.move(s, Math.cos(s.angle) * 1000, s.y);
+                s.flee = true;
+                war.move(s, Math.cos(s.angle) * 150, s.y);
             }
             return SpacewarScriptResult.CONTINUE;
         }

--- a/src/hu/openig/scripting/missions/Mission17.java
+++ b/src/hu/openig/scripting/missions/Mission17.java
@@ -185,10 +185,11 @@ public class Mission17 extends Mission {
         }
         for (SpacewarStructure s : war.structures(g)) {
             war.stop(s);
+            s.flee = true;
             if (war.battle().helperPlanet == null) {
-                war.move(s, war.space().width + 1000, s.y);
+                war.move(s, war.space().width + 150, s.y);
             } else {
-                war.move(s, -1000, s.y);
+                war.move(s, -150, s.y);
             }
         }
 

--- a/src/hu/openig/scripting/missions/Mission17.java
+++ b/src/hu/openig/scripting/missions/Mission17.java
@@ -183,15 +183,7 @@ public class Mission17 extends Mission {
                 return SpacewarScriptResult.CONTINUE;
             }
         }
-        for (SpacewarStructure s : war.structures(g)) {
-            war.stop(s);
-            s.flee = true;
-            if (war.battle().helperPlanet == null) {
-                war.move(s, war.space().width + 150, s.y);
-            } else {
-                war.move(s, -150, s.y);
-            }
-        }
+        war.battle().enemyFlee = true;
 
         return SpacewarScriptResult.PLAYER_WIN;
     }

--- a/src/hu/openig/scripting/missions/Mission19.java
+++ b/src/hu/openig/scripting/missions/Mission19.java
@@ -9,28 +9,14 @@
 package hu.openig.scripting.missions;
 
 import hu.openig.core.Action0;
-import hu.openig.model.BattleInfo;
+import hu.openig.model.*;
 import hu.openig.model.BattleProjectile.Mode;
 import hu.openig.model.Chats.Chat;
 import hu.openig.model.Chats.Node;
-import hu.openig.model.Fleet;
-import hu.openig.model.FleetTask;
-import hu.openig.model.InventoryItem;
-import hu.openig.model.ModelUtils;
-import hu.openig.model.ObjectiveState;
-import hu.openig.model.Planet;
-import hu.openig.model.Player;
-import hu.openig.model.ResearchSubCategory;
-import hu.openig.model.ResearchType;
-import hu.openig.model.SoundTarget;
-import hu.openig.model.SoundType;
-import hu.openig.model.SpacewarScriptResult;
-import hu.openig.model.SpacewarStructure;
 import hu.openig.model.SpacewarStructure.StructureType;
-import hu.openig.model.SpacewarWorld;
 import hu.openig.utils.XElement;
 
-import java.awt.Dimension;
+import java.awt.*;
 
 /**
  * Mission 19: blockade of Zeuson.
@@ -181,12 +167,11 @@ public class Mission19 extends Mission {
 
             if (battle.helperPlanet != null && battle.helperPlanet.owner == battle.attacker.owner) {
                 if (battle.helperPlanet.id.equals("Zeuson")) {
-
+                    war.battle().showLanding = true;
                     Dimension d = war.space();
                     for (SpacewarStructure s : war.structures()) {
                         if (s.type == StructureType.SHIP) {
                             s.x = d.width - s.x - 100;
-                            s.angle -= Math.PI;
                         }
                     }
 
@@ -210,9 +195,24 @@ public class Mission19 extends Mission {
 
                 war.battle().enemyFlee = true;
             } else {
+
+                int facing = war.facing();
+                if (war.battle().invert) {
+                    facing = -facing;
+                }
                 for (SpacewarStructure s : war.structures(freeTraders())) {
                     if (s.attackUnit == null) {
-                        war.move(s, Math.cos(s.angle) * -150, s.y);
+                        s.flee = true; //Needed to allow pathing outside the screen
+                        war.move(s, Math.max(facing * 150, facing * (war.space().width + 150)), s.y);
+                    }
+                }
+            }
+            if (war.battle().showLanding && war.battle().invert) {
+                Point lp = war.landingPlace();
+                for (SpacewarStructure s : war.structures(freeTraders())) {
+                    double d1 = lp.distance(s.x, s.y);
+                    if ((d1 <= 5)) {
+                        war.removeStructure(s);
                     }
                 }
             }

--- a/src/hu/openig/scripting/missions/Mission19.java
+++ b/src/hu/openig/scripting/missions/Mission19.java
@@ -212,7 +212,7 @@ public class Mission19 extends Mission {
             } else {
                 for (SpacewarStructure s : war.structures(freeTraders())) {
                     if (s.attackUnit == null) {
-                        war.move(s, Math.cos(s.angle) * 1000, s.y);
+                        war.move(s, Math.cos(s.angle) * -150, s.y);
                     }
                 }
             }

--- a/src/hu/openig/utils/U.java
+++ b/src/hu/openig/utils/U.java
@@ -43,6 +43,10 @@ import java.util.zip.ZipFile;
  * @author akarnokd
  */
 public final class U {
+    /** Good enough precision PI. */
+    public static final double ONE_PI = 3.1415;
+    /** Good enough precision PI times two. */
+    public static final double TWO_PI = 6.283;
     /** Constructor. */
     private U() {
         // utility class
@@ -1021,5 +1025,12 @@ public final class U {
                 return comp.compare(o2, o1);
             }
         };
+    }
+    /**
+     * A very fast calculation of a good enough normalized angle.
+     * @return the normalized angle between -PI and +PI.
+     */
+    public static double normalizedAngle(double angle) {
+        return angle - TWO_PI * Math.floor((angle + ONE_PI) / TWO_PI);
     }
 }


### PR DESCRIPTION
Implemented basic pathfinding for space war based on ground war methods so for now all ships are treated as 1x1 sized, but that can be iterated upon.
For this I created a class structure for common pathing and movement methods that are used by both ground war and space war battles since most of the mechanics are the same.
There were some changes made to how spacewar movement is handled to fit the new pathing mechanics. Scripting was also updated to work with the new code.
Also added a node weighing mechanic to encourage spreading paths when groups of units are moving together. A weight is added to each node on the grid for each path touching that node. This weight is used when calculating the distance between two neighboring nodes. It is very basic and does not differentiate between the players nor does it use weights on vertices, but it does the job.
The pathfinding in spacewar can be disabled in the settings to use freeform movement.

Besides the pathfinding there are some additional changes:
 - Kamikaze fighters also use pathing and are now controllable until impact. This means that is the target if destroyed before impact the fighter will stop or it can be ordered to stop.
 - Ships no longer chase down incoming missiles. They will still prioritize them if they come into range, but do that while standing still.
 - Groundwar unit rotation and angle is calculated based on the underlying pathing/surface grid and not the rendered surface. Their angle is converted to isometric when a unit is drawn.
 - Added a lightweight angle normalization method to the U utils class to get a "good enough" normalized angle fast.
 - Fixed again ground units not firing at buildings, hopefully for the last time.
 - Zeuson governor mission scripting now uses landing zone when the Unknown fleet is intercepted near the planet.
 - Fixed ground units not following move orders when near an enemy unit.
