### PR TITLE
Added check when diplomatic relations change with players.

### DIFF
--- a/src/hu/openig/mechanics/AITrader.java
+++ b/src/hu/openig/mechanics/AITrader.java
@@ -155,11 +155,9 @@ public class AITrader implements AIManager {
                 fleets.add(tf);
             }
         }
-        Set<String> drs = new HashSet<>();
+        Set<Player> drs = new HashSet<>();
         for (DiplomaticRelation dr0 : world.relations) {
-            if (dr0.first.equals(world.player.id)
-
-                    || dr0.second.equals(world.player.id)) {
+            if (dr0.first == player || dr0.second == player) {
                 if (dr0.tradeAgreement) {
                     if (dr0.first.equals(world.player.id)) {
                         drs.add(dr0.second);
@@ -175,7 +173,7 @@ public class AITrader implements AIManager {
                 if (pl.owner == world.player
 
                         || (pl.owner == player)
-                        || drs.contains(pl.owner.id)) {
+                        || drs.contains(pl.owner)) {
                     planets.add(pl);
                 }
             }
@@ -611,10 +609,10 @@ public class AITrader implements AIManager {
         fleetTurnedBack.add(f);
         Planet pl = lastVisitedPlanet.get(f);
         if (pl != null) {
-            f.targetPlanet(pl);
+            f.setTargetPlanet(pl);
         } else {
             Exceptions.add(new AssertionError("Fleet " + f.id + " has no previous planet to return to!"));
-            f.targetPlanet(nearest(player.world.planets.values(), f));
+            f.setTargetPlanet(nearest(player.world.planets.values(), f));
         }
         f.mode = FleetMode.MOVE;
     }

--- a/src/hu/openig/mechanics/AchievementManager.java
+++ b/src/hu/openig/mechanics/AchievementManager.java
@@ -373,8 +373,8 @@ public final class AchievementManager {
             ap.displayProgress = false;
             ap.max = 1;
             for (DiplomaticRelation dr : t.relations) {
-                if (dr.first.equals(u.id) || dr.second.equals(u.id)) {
-                    Player otherPlayer = dr.first.equals(u.id) ? t.player(dr.second) : t.player(dr.first);
+                if (dr.first == u || dr.second == u) {
+                    Player otherPlayer = (dr.first == u ? dr.second : dr.first);
                     if (dr.full
                             && !otherPlayer.race.equals(u.race)
                             && !otherPlayer.race.equals("traders")

--- a/src/hu/openig/mechanics/AttackPlanner.java
+++ b/src/hu/openig/mechanics/AttackPlanner.java
@@ -254,7 +254,7 @@ public class AttackPlanner extends Planner {
                 DiplomaticRelation dr = world.relations.get(f.fleet.owner);
 
                 if (dr != null && dr.full && !dr.strongAlliance) {
-                    if (dr.value < p.warThreshold && hasActiveAlliance(dr.alliancesAgainst)) {
+                    if (dr.value < p.warThreshold && !hasActiveAlliance(dr.alliancesAgainst)) {
                         candidates.add(f);
                     }
                 }
@@ -305,9 +305,7 @@ public class AttackPlanner extends Planner {
                 }
                 DiplomaticRelation dr = world.relations.get(p.owner);
                 if (dr != null && dr.full && !dr.strongAlliance) {
-                    if (dr.value < this.p.warThreshold
-
-                            && !hasActiveAlliance(dr.alliancesAgainst)) {
+                    if (dr.value < this.p.warThreshold && !hasActiveAlliance(dr.alliancesAgainst)) {
                         if (planetValue(p) > 0) {
                             candidates.add(p);
                             enemies.add(p.owner);

--- a/src/hu/openig/mechanics/Radar.java
+++ b/src/hu/openig/mechanics/Radar.java
@@ -170,11 +170,10 @@ public final class Radar {
         // share radar knowledge
         for (Player p : world.players.values()) {
             for (DiplomaticRelation dr : world.relations) {
-                if ((dr.first.equals(p.id) || dr.second.equals(p.id))
-
+                if ((dr.first == p || dr.second == p)
                         && dr.value >= world.params().radarShareLimit()
                         && !dr.alliancesAgainst.isEmpty()) {
-                    Player p2 = world.players.get((dr.first.equals(p.id)) ? dr.second : dr.first);
+                    Player p2 = (dr.first == p ? dr.second : dr.first);
 
                     for (Map.Entry<Fleet, FleetKnowledge> fe : p.fleets.entrySet()) {
                         updateKnowledge(world, p2, fe.getKey(), fe.getValue());

--- a/src/hu/openig/model/AIWorld.java
+++ b/src/hu/openig/model/AIWorld.java
@@ -215,11 +215,10 @@ public class AIWorld {
         now = player.world.time.getTime();
 
         for (DiplomaticRelation dr : player.world.relations) {
-            if (dr.first.equals(player.id)) {
-                relations.put(player.world.players.get(dr.second), dr);
-            } else
-            if (dr.second.equals(player.id)) {
-                relations.put(player.world.players.get(dr.first), dr);
+            if (dr.first == player) {
+                relations.put(dr.second, dr);
+            } else if (dr.second == player) {
+                relations.put(dr.first, dr);
             }
         }
         for (Player p : player.world.players.values()) {

--- a/src/hu/openig/model/Fleet.java
+++ b/src/hu/openig/model/Fleet.java
@@ -78,7 +78,7 @@ public class Fleet implements Named, Owned, HasInventory, HasPosition {
      * Set the new target planet and save the current target into {@code arrivedAt}.
      * @param p the new target planet
      */
-    public void targetPlanet(Planet p) {
+    public void setTargetPlanet(Planet p) {
         if (p == null) {
             arrivedAt = targetPlanet;
         } else {

--- a/src/hu/openig/model/Player.java
+++ b/src/hu/openig/model/Player.java
@@ -111,6 +111,8 @@ public class Player {
     public int colonizationLimit = -1;
     /** The limit where the AI considers attacking the other party. */
     public int warThreshold = 45;
+    /** The limit above which the AI cancels all ongoing attacks against the other party. */
+    public int endHostilitiesThreshold = 55;
     /** The negotiation offers from players. */
     public final Map<String, DiplomaticOffer> offers = new LinkedHashMap<>();
     /** The factor for police-to-morale conversion. */
@@ -340,7 +342,7 @@ public class Player {
      */
     public void setStance(Player p, int value) {
         DiplomaticRelation dr = world.establishRelation(this, p);
-        dr.value = value;
+        dr.updateDrValue(value);
     }
     /**
 
@@ -349,7 +351,7 @@ public class Player {
      * @return does this player know the other player? */
     public boolean knows(Player other) {
         DiplomaticRelation dr = world.getRelation(this, other);
-        return dr != null && (dr.second.equals(other.id) || (dr.first.equals(other.id) && dr.full));
+        return dr != null && (dr.second == other || (dr.first == other && dr.full));
     }
     /**
      * @return the set ow known players
@@ -357,11 +359,11 @@ public class Player {
     public Map<Player, DiplomaticRelation> knownPlayers() {
         Map<Player, DiplomaticRelation> result = new LinkedHashMap<>();
         for (DiplomaticRelation dr : world.relations) {
-            if (dr.first.equals(id)) {
-                result.put(world.players.get(dr.second), dr);
+            if (dr.first.id.equals(id)) {
+                result.put(dr.second, dr);
             }
-            if (dr.second.equals(id) && dr.full) {
-                result.put(world.players.get(dr.first), dr);
+            if (dr.second.id.equals(id) && dr.full) {
+                result.put(dr.first, dr);
             }
         }
         return result;

--- a/src/hu/openig/model/World.java
+++ b/src/hu/openig/model/World.java
@@ -2053,7 +2053,7 @@ public class World implements ModelLookup {
             }
             s0 = xfleet.get("target-planet", null);
             if (s0 != null) {
-                f.targetPlanet(planets.get(s0));
+                f.setTargetPlanet(planets.get(s0));
             }
             s0 = xfleet.get("arrived-at", null);
             if (s0 != null) {
@@ -2878,8 +2878,8 @@ public class World implements ModelLookup {
     public DiplomaticRelation getRelation(Player first, Player second) {
         if (first != null && second != null) {
             for (DiplomaticRelation dr : relations) {
-                if ((dr.first.equals(first.id) && dr.second.equals(second.id))
-                        || (dr.first.equals(second.id) && dr.second.equals(first.id))) {
+                if ((dr.first == first && dr.second == second)
+                        || (dr.first == second && dr.second == first)) {
                     return dr;
                 }
             }
@@ -2910,8 +2910,8 @@ public class World implements ModelLookup {
      */
     public DiplomaticRelation createDiplomaticRelation(Player first, Player second) {
         DiplomaticRelation dr = new DiplomaticRelation();
-        dr.first = first.id;
-        dr.second = second.id;
+        dr.first = first;
+        dr.second = second;
         dr.value = (first.initialStance + second.initialStance) / 2d;
         relations.add(dr);
         return dr;
@@ -2924,8 +2924,8 @@ public class World implements ModelLookup {
         XElement xrels = xworld.add("relations");
         for (DiplomaticRelation dr : relations) {
             XElement xrel = xrels.add("relation");
-            xrel.set("first", dr.first);
-            xrel.set("second", dr.second);
+            xrel.set("first", dr.first.id);
+            xrel.set("second", dr.second.id);
             xrel.set("full", dr.full);
             xrel.set("trade-agreement", dr.tradeAgreement);
             xrel.set("strong-alliance", dr.strongAlliance);
@@ -3487,11 +3487,10 @@ public class World implements ModelLookup {
             int maxWar = Math.max(p1.warThreshold, p2.warThreshold);
             // each attack degrades relations a bit
             if (dr.value >= maxWar) {
-                dr.value = minWar - 1;
+                dr.updateDrValue(minWar - 1);
             } else {
-                dr.value -= 1;
+                dr.updateDrValue(dr.value - 1);
             }
-            dr.value = Math.max(0, dr.value);
             dr.tradeAgreement = false;
             dr.wontTalk(true);
             dr.lastContact = time.getTime();

--- a/src/hu/openig/screen/items/AbandonColonyScreen.java
+++ b/src/hu/openig/screen/items/AbandonColonyScreen.java
@@ -259,8 +259,8 @@ public class AbandonColonyScreen extends ScreenBase {
                             p.morale(p.morale() - 50);
                         }
                         for (DiplomaticRelation dr : world().relations) {
-                            if (dr.full && (dr.first.equals(player().id) || dr.second.equals(player().id))) {
-                                dr.value = Math.max(0, dr.value - 5);
+                            if (dr.full && (dr.first == player() || dr.second == player())) {
+                                dr.updateDrValue(dr.value - 5);
                             }
                         }
                     } else {
@@ -268,8 +268,8 @@ public class AbandonColonyScreen extends ScreenBase {
                             p.morale(p.morale() - 20);
                         }
                         for (DiplomaticRelation dr : world().relations) {
-                            if (dr.full && (dr.first.equals(player().id) || dr.second.equals(player().id))) {
-                                dr.value = Math.max(0, dr.value - 25);
+                            if (dr.full && (dr.first == player() || dr.second == player())) {
+                                dr.updateDrValue(dr.value - 25);
                             }
                         }
                     }
@@ -292,8 +292,8 @@ public class AbandonColonyScreen extends ScreenBase {
                         }
                     } else {
                         for (DiplomaticRelation dr : world().relations) {
-                            if (dr.first.equals(player().id) || dr.second.equals(player().id)) {
-                                dr.value = Math.max(0, dr.value - 5);
+                            if (dr.first == player() || dr.second == player()) {
+                                dr.updateDrValue(dr.value - 5);
                             }
                         }
                         List<Planet> ps = new ArrayList<>();

--- a/src/hu/openig/screen/items/DiplomacyScreen.java
+++ b/src/hu/openig/screen/items/DiplomacyScreen.java
@@ -449,7 +449,7 @@ public class DiplomacyScreen extends WalkableScreen {
             messagePhase = 2;
 
             DiplomaticRelation dr = world().getRelation(player(), other);
-            dr.value = Math.max(0, Math.min(100, dr.value + change));
+            dr.updateDrValue(dr.value + change);
         } else
         if (messagePhase == 2) {
             returnToOptions();
@@ -1345,11 +1345,8 @@ public class DiplomacyScreen extends WalkableScreen {
             ApproachType at = ApproachType.NEUTRAL;
 
             ResponseMode m = other.ai.diplomacy(player(),
-
                     a.first.type,
-
                     at,
-
                     a.second);
 
             displayResults(a.first, a.second.name, at, m);
@@ -1370,10 +1367,12 @@ public class DiplomacyScreen extends WalkableScreen {
         dr = world().getRelation(player(), enemy);
         dr.alliancesAgainst.remove(other.id);
 
+        dr.updateDrValue(Math.min(dr.value, 30));
+
         dr = world().getRelation(other, enemy);
         dr.alliancesAgainst.remove(player().id);
 
-        dr.value = Math.min(dr.value, 30);
+        dr.updateDrValue(Math.min(dr.value, 30));
     }
     /**
      * Perform generic topic negotiation.
@@ -1383,11 +1382,8 @@ public class DiplomacyScreen extends WalkableScreen {
         ApproachType at = ApproachType.NEUTRAL;
 
         ResponseMode m = other.ai.diplomacy(player(),
-
                 neg.type,
-
                 at,
-
                 null);
 
         if (m == ResponseMode.YES) {
@@ -1492,7 +1488,7 @@ public class DiplomacyScreen extends WalkableScreen {
                         DiplomaticRelation dr = world().getRelation(world().player, other);
                         if (na.callType == CallType.ALLIANCE) {
                             if (dr.value < 91) {
-                                dr.value = 91;
+                                dr.updateDrValue(91);
                             }
                         } else
                         if (na.callType == CallType.MONEY) {
@@ -1503,7 +1499,7 @@ public class DiplomacyScreen extends WalkableScreen {
                                 other.statistics.moneyIncome.value += mny;
                                 player().statistics.moneySpent.value += mny;
                                 if (dr.value < 95) {
-                                    dr.value += 5;
+                                    dr.updateDrValue(dr.value + 5);
                                 }
                             } else {
                                 commons.control().displayError(format("diplomacy.not_enough_money", other.name));

--- a/src/hu/openig/screen/items/LoadSaveScreen.java
+++ b/src/hu/openig/screen/items/LoadSaveScreen.java
@@ -141,18 +141,18 @@ public class LoadSaveScreen extends ScreenBase implements LoadSaveScreenAPI {
     AuidoSettingsPanel audioContents = new AuidoSettingsPanel();
     /** The UI panel element for control settings. */
     @Settings(page = SettingsPage.CONTROL)
-    /** The inner contents of the UI panel element for control settings. */
     UIPanel controlSettings;
+    /** The inner contents of the UI panel element for control settings. */
     ControlSettingsPanel controlContents = new ControlSettingsPanel();
     /** The UI panel element for gameplay settings. */
     @Settings(page = SettingsPage.GAMEPLAY)
-    /** The inner contents of the UI panel element for gameplay settings. */
     UIPanel gamePlaySettings;
+    /** The inner contents of the UI panel element for gameplay settings. */
     GamePlaySettingsPanel gpContents = new GamePlaySettingsPanel();
     /** The UI panel element for visual settings. */
     @Settings(page = SettingsPage.VISUAL)
-    /** The inner contents of the UI panel element for visual settings. */
     UIPanel visualSettings;
+    /** The inner contents of the UI panel element for visual settings. */
     VisualSettingsPanel visualContents = new VisualSettingsPanel();
     /** The save name. */
     @Settings(page = SettingsPage.LOAD_SAVE)
@@ -905,7 +905,6 @@ public class LoadSaveScreen extends ScreenBase implements LoadSaveScreenAPI {
                 public void invoke() {
                     buttonSound(SoundType.CLICK_MEDIUM_2);
                     config.spacewarFreeformMovement = freeformSpacewarMovement.selected();
-                    System.out.println("spacewarFreeformMovement in config: " + config.spacewarFreeformMovement + " Config Object:" + config);
 
                 }
             };
@@ -954,7 +953,6 @@ public class LoadSaveScreen extends ScreenBase implements LoadSaveScreenAPI {
                 public void invoke() {
                     buttonSound(SoundType.CLICK_MEDIUM_2);
                     config.automaticBattle = automaticBattle.selected();
-                    System.out.println("automaticBattle in config: " + config.automaticBattle + " Config Object:" + config);
                 }
             };
 
@@ -1793,7 +1791,6 @@ public class LoadSaveScreen extends ScreenBase implements LoadSaveScreenAPI {
                 public void invoke() {
                     buttonSound(SoundType.CLICK_MEDIUM_2);
                     config.computerVoiceScreen = computerVoiceScreen.selected();
-                    System.out.println("computerVoiceScreen in config: " + config.computerVoiceScreen + " Config Object:" + config);
                 }
             };
             computerVoiceNotify = new UICheckBox(get("settings.computer_voice_notify"), 14, commons.common().checkmark, commons.text());

--- a/src/hu/openig/screen/items/StarmapScreen.java
+++ b/src/hu/openig/screen/items/StarmapScreen.java
@@ -2306,19 +2306,19 @@ public class StarmapScreen extends ScreenBase {
                     Planet p = getPlanetAt(fleet().owner, e.x, e.y, false);
                     Fleet f = getFleetAt(fleet().owner, e.x, e.y, false, fleet());
                     if (p != null) {
-                        fleet().targetPlanet(p);
+                        fleet().setTargetPlanet(p);
                         fleet().targetFleet = null;
                         fleet().mode = FleetMode.MOVE;
                         fleet().task = FleetTask.MOVE;
                     } else
 
                     if (f != null) {
-                        fleet().targetPlanet(null);
+                        fleet().setTargetPlanet(null);
                         fleet().targetFleet = f;
                         fleet().mode = FleetMode.MOVE;
                         fleet().task = FleetTask.MOVE;
                     } else {
-                        fleet().targetPlanet(null);
+                        fleet().setTargetPlanet(null);
                         fleet().targetFleet = null;
                         fleet().mode = FleetMode.MOVE;
                         fleet().task = FleetTask.MOVE;

--- a/src/hu/openig/scripting/missions/Mission10.java
+++ b/src/hu/openig/scripting/missions/Mission10.java
@@ -80,7 +80,7 @@ public class Mission10 extends Mission {
         // ----------------------------------------------------------------
         tagFleet(pf, "Mission-10-Governor");
         pf.mode = FleetMode.MOVE;
-        pf.targetPlanet(nax);
+        pf.setTargetPlanet(nax);
 
         addScripted(pf);
 

--- a/src/hu/openig/scripting/missions/Mission11.java
+++ b/src/hu/openig/scripting/missions/Mission11.java
@@ -116,7 +116,7 @@ public class Mission11 extends Mission {
 
         Planet target = selectTarget();
 
-        f.targetPlanet(target);
+        f.setTargetPlanet(target);
 
         garthog.changeInventoryCount(research("SpySatellite1"), 1);
         DefaultAIControls.actionDeploySatellite(garthog, target, research("SpySatellite1"));

--- a/src/hu/openig/scripting/missions/Mission14.java
+++ b/src/hu/openig/scripting/missions/Mission14.java
@@ -112,7 +112,7 @@ public class Mission14 extends Mission {
             ii.tag = "Mission-14-Garthog";
         }
         Planet nc = planet("New Caroline");
-        f.targetPlanet(nc);
+        f.setTargetPlanet(nc);
         f.mode = FleetMode.MOVE;
         f.task = FleetTask.SCRIPT;
         garthog.changeInventoryCount(research("SpySatellite1"), 1);
@@ -155,7 +155,7 @@ public class Mission14 extends Mission {
             Fleet tf = findTaggedFleet("Mission-14-Garthog", garthog);
             if (tf != null) {
                 Planet nc = planet("New Caroline");
-                tf.targetPlanet(nc);
+                tf.setTargetPlanet(nc);
                 tf.mode = FleetMode.MOVE;
                 tf.task = FleetTask.SCRIPT;
             } else {

--- a/src/hu/openig/scripting/missions/Mission25.java
+++ b/src/hu/openig/scripting/missions/Mission25.java
@@ -43,8 +43,8 @@ public class Mission25 extends Mission {
         if (stage == M25.RUNNING) {
             // make sure dargslan keep hating the player the most
             for (DiplomaticRelation dr : world.relations) {
-                if (dr.full && (dr.first.equals("Dargslan") || dr.second.equals("Dargslan"))) {
-                    if (!dr.first.equals("Empire") && !dr.second.equals("Empire")) {
+                if (dr.full && (dr.first.id.equals("Dargslan") || dr.second.id.equals("Dargslan"))) {
+                    if (!dr.first.id.equals("Empire") && !dr.second.id.equals("Empire")) {
                         dr.value = 10;
                     } else {
                         dr.value = 1;

--- a/src/hu/openig/scripting/missions/Mission4.java
+++ b/src/hu/openig/scripting/missions/Mission4.java
@@ -167,7 +167,7 @@ public class Mission4 extends Mission {
         // make sure the temporary Pirates2 player has no relations left.
         for (int i = world.relations.size() - 1; i >= 0; i--) {
             DiplomaticRelation r = world.relations.get(i);
-            if (r.first.equals("Pirates2") || r.second.equals("Pirates2")) {
+            if (r.first.id.equals("Pirates2") || r.second.id.equals("Pirates2")) {
                 world.relations.remove(i);
             }
         }

--- a/src/hu/openig/scripting/missions/Mission6.java
+++ b/src/hu/openig/scripting/missions/Mission6.java
@@ -135,7 +135,7 @@ public class Mission6 extends Mission {
                 Planet ach = planet("Achilles");
                 double d = Math.hypot(ach.x - garthog.x, ach.y - garthog.y);
                 if (d <= 1) {
-                    garthog.targetPlanet(ach);
+                    garthog.setTargetPlanet(ach);
                     garthog.mode = FleetMode.ATTACK;
                     garthog.task = FleetTask.SCRIPT;
                 }
@@ -217,7 +217,7 @@ public class Mission6 extends Mission {
             ii.tag = "Mission-6-Garthog";
         }
         Planet ach = planet("Achilles");
-        f.targetPlanet(ach);
+        f.setTargetPlanet(ach);
         f.mode = FleetMode.ATTACK;
         f.task = FleetTask.SCRIPT;
         garthog.changeInventoryCount(research("SpySatellite1"), 1);

--- a/src/hu/openig/scripting/missions/Mission9.java
+++ b/src/hu/openig/scripting/missions/Mission9.java
@@ -156,7 +156,7 @@ public class Mission9 extends Mission {
             ii.tag = "Mission-9-Smuggler";
         }
         pf.mode = FleetMode.MOVE;
-        pf.targetPlanet(sst);
+        pf.setTargetPlanet(sst);
 
         addScripted(pf);
 
@@ -259,7 +259,7 @@ public class Mission9 extends Mission {
                 } else
                 if (slipped) {
                     // resume flight
-                    smg.targetPlanet(sst);
+                    smg.setTargetPlanet(sst);
                     smg.task = FleetTask.SCRIPT;
                 }
             }


### PR DESCRIPTION
Added check when diplomatic relations change with players.
Now this is only used for stopping fleets mid attack. The function checks if relations improved and if the value is above the Player object's new threshold value "endHostilitiesThreshold". The higher of the two opposing sides' is taken into account.

Fixed a condition that prevented fleets from attacking other fleets.
Removed some leftover debug messages.

Should resolve #1135