### PR TITLE
Space war pathing mostly

### DIFF
--- a/src/hu/openig/mechanics/FreeFormSpaceWarMovementHandler.java
+++ b/src/hu/openig/mechanics/FreeFormSpaceWarMovementHandler.java
@@ -22,6 +22,8 @@ public class FreeFormSpaceWarMovementHandler extends WarMovementHandler {
     }
 
     @Override
+    public void initUnits() { }
+    @Override
     public void removeUnit(WarUnit unit) { }
     @Override
     public void setMovementGoal(WarUnit unit, Location loc) {

--- a/src/hu/openig/mechanics/SimpleSpaceWarMovementHandler.java
+++ b/src/hu/openig/mechanics/SimpleSpaceWarMovementHandler.java
@@ -52,13 +52,4 @@ public class SimpleSpaceWarMovementHandler extends SimpleWarMovementHandler {
         }
         return super.ignoreObstacles(loc, unit);
     }
-
-    @Override
-    boolean isPassable(Location loc, WarUnit unit) {
-        SpacewarStructure sws = (SpacewarStructure) unit;
-        if (sws.kamikaze > 0 && loc.equals(sws.getAttackTarget().location())) {
-            return true;
-        }
-        return super.isPassable(loc, unit);
-    }
 }

--- a/src/hu/openig/mechanics/SimpleWarMovementHandler.java
+++ b/src/hu/openig/mechanics/SimpleWarMovementHandler.java
@@ -44,6 +44,10 @@ public abstract class SimpleWarMovementHandler extends WarMovementHandler {
         this.gridSizeX = gridSizeX;
         this.gridSizeY = gridSizeY;
         this.units = units;
+    }
+
+    @Override
+    public void initUnits() {
         for (WarUnit wunit : units) {
             Location pfl = wunit.location();
             Set<WarUnit> set = unitsForPathfinding.get(pfl);
@@ -96,22 +100,13 @@ public abstract class SimpleWarMovementHandler extends WarMovementHandler {
             }
             unit.setNextMove(unit.getPath().peekFirst());
             unit.setNextRotate(unit.getNextMove());
-
-            // is the next move location still passable?
-            if (!ignoreObstacles(unit.getNextMove(), unit) && (!isPassable(unit.getNextMove(), unit) || isCellReserved(unit.getNextMove(), unit))) {
-                // trigger replanning
-                repath(unit);
-                return false;
-            }
         }
 
-        if (!ignoreObstacles(unit.getNextMove(), unit) && unitsForPathfinding.get(unit.getNextMove()) != null) {
-            for (WarUnit wunit : unitsForPathfinding.get(unit.getNextMove())) {
-                if (wunit != unit && !wunit.inMotion() && !needsRotation(wunit, wunit.getNextRotate())) {
-                    repath(unit);
-                    return false;
-                }
-            }
+        // is the next move location still passable?
+        if (!ignoreObstacles(unit.getNextMove(), unit) && (!isPassable(unit.getNextMove(), unit) || isCellReserved(unit.getNextMove(), unit))) {
+            // trigger replanning
+            repath(unit);
+            return false;
         }
 
         if (unit.getNextRotate() != null && rotateStep(unit, unit.getNextRotate().x, unit.getNextRotate().y)) {

--- a/src/hu/openig/mechanics/SpaceWarMovementHandler.java
+++ b/src/hu/openig/mechanics/SpaceWarMovementHandler.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2008-present, David Karnok & Contributors
+ * The file is part of the Open Imperium Galactica project.
+ *
+ * The code should be distributed under the LGPL license.
+ * See http://www.gnu.org/licenses/lgpl.html for details.
+ */
+
+package hu.openig.mechanics;
+
+import hu.openig.core.Func1;
+import hu.openig.core.Location;
+import hu.openig.core.Pathfinding;
+import hu.openig.model.ResearchSubCategory;
+import hu.openig.model.SpacewarStructure;
+import hu.openig.model.WarUnit;
+import hu.openig.utils.Exceptions;
+
+import java.util.*;
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * Class for handling pathfinding and movement of space war ships.
+ * All ships have the size 1x1 with big ships(battleships and cruisers) having a 3x3 exclusion
+ * zone for other big ships. Fighters ignore this zone.
+ */
+public class SpaceWarMovementHandler extends SimpleSpaceWarMovementHandler {
+
+    public SpaceWarMovementHandler(ScheduledExecutorService commonExecutorPool, int cellSize, int simulationDelay, List<? extends WarUnit> units, int gridSizeX, int gridSizeY) {
+        super(commonExecutorPool, cellSize, simulationDelay, units, gridSizeX, gridSizeY);
+    }
+
+    @Override
+    public void initUnits() {
+        for (WarUnit wunit : units) {
+            Location pfl = wunit.location();
+            Set<WarUnit> set = unitsForPathfinding.get(pfl);
+            if (set == null) {
+                set = new HashSet<>();
+                unitsForPathfinding.put(pfl, set);
+            }
+            set.add(wunit);
+            SpacewarStructure sws = (SpacewarStructure) wunit;
+            if (sws.item.type.category == ResearchSubCategory.SPACESHIPS_FIGHTERS) {
+                sws.setPathingMethod(getFighterPathfinding(sws));
+            } else if (sws.item.type.category == ResearchSubCategory.SPACESHIPS_CRUISERS || sws.item.type.category == ResearchSubCategory.SPACESHIPS_BATTLESHIPS) {
+                sws.setPathingMethod(getCapShipPathfinding(sws));
+            } else if (sws.item.type.category == ResearchSubCategory.SPACESHIPS_STATIONS) {
+                // Stations have no exclusion zone, they are just big and occupy a 3x3 space.
+                for (Location neighbor : sws.location().getListOfNeighbors()) {
+                    set = unitsForPathfinding.get(neighbor);
+                    if (set == null) {
+                        set = new HashSet<>();
+                        unitsForPathfinding.put(neighbor, set);
+                    }
+                    set.add(sws);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void removeUnit(WarUnit unit) {
+        super.removeUnit(unit);
+        if (((SpacewarStructure) unit).item.type.category == ResearchSubCategory.SPACESHIPS_STATIONS) {
+            for (Location locToRemove : unit.location().getListOfNeighbors()) {
+                Set<WarUnit> set = unitsForPathfinding.get(locToRemove);
+                if (set != null) {
+                    if (!set.remove(unit)) {
+                        Exceptions.add(new AssertionError(String.format("Unit was not found at location %s, %s%n", locToRemove.x, locToRemove.y)));
+                    }
+                }
+            }
+        }
+    }
+    @Override
+    boolean reserveCellFor(WarUnit unit) {
+        SpacewarStructure sws = (SpacewarStructure) unit;
+        if (sws.item.type.category == ResearchSubCategory.SPACESHIPS_FIGHTERS) {
+            return super.reserveCellFor(unit);
+        } else {
+            return reserveCellForCapitalShip(unit);
+        }
+    }
+    @Override
+    boolean isCellReserved(Location loc, WarUnit unit) {
+        SpacewarStructure sws = (SpacewarStructure) unit;
+        if (sws.item.type.category == ResearchSubCategory.SPACESHIPS_FIGHTERS) {
+            return super.isCellReserved(loc, unit);
+        } else {
+            return isCellReservedForCapitalShip(loc, unit);
+        }
+    }
+    /**
+     * Reserve the next movement cell for the capital ship.
+     * @param unit the unit
+     * @return true if the next cell is successfully reserved
+     */
+    boolean reserveCellForCapitalShip(WarUnit unit) {
+        if (unitsForPathfinding.get(unit.getNextMove()) != null) {
+            for (WarUnit wunit : unitsForPathfinding.get(unit.getNextMove())) {
+                if (wunit != unit) {
+                    return false;
+                }
+            }
+        } else if (isCellReserved(unit.getNextMove(), unit)) {
+            return false;
+        }
+        //Check the surrounding cells ignoring fighters
+        ArrayList<Location> locationsToCheck = unit.getNextMove().getListOfNeighbors();
+        locationsToCheck.remove(unit.location());
+        locationsToCheck.removeAll(unit.location().getListOfNeighbors());
+        for (Location loc : locationsToCheck) {
+            if (unitsForPathfinding.get(loc) != null) {
+                for (WarUnit wunit : unitsForPathfinding.get(loc)) {
+                    if (wunit != unit && ((SpacewarStructure) wunit).item.type.category != ResearchSubCategory.SPACESHIPS_FIGHTERS) {
+                        return false;
+                    }
+                }
+            }
+        }
+        if (isCellReservedForCapitalShip(unit.getNextMove(), unit)) {
+            return false;
+        }
+
+        reservedCells.put(unit.getNextMove(), unit);
+        return true;
+    }
+    /**
+     * Check if a cell is reserved for a capital ship.
+     * @param loc the location to check
+     * @param unit the unit
+     * @return true if the cell is already reserved
+     */
+    boolean isCellReservedForCapitalShip(Location loc, WarUnit unit) {
+        //Check the surrounding cells ignoring fighters
+        SpacewarStructure sws = (SpacewarStructure) unit;
+        if (reservedCells.get(loc) != null && reservedCells.get(loc) != unit) {
+            return true;
+        }
+        ArrayList<Location> locationsToCheck = loc.getListOfNeighbors();
+        // Do not check currently occupied locations.
+        locationsToCheck.remove(unit.location());
+        locationsToCheck.removeAll(unit.location().getListOfNeighbors());
+        for (Location locToCheck : locationsToCheck) {
+            if (reservedCells.get(locToCheck) != null && reservedCells.get(locToCheck) != unit && ((SpacewarStructure)reservedCells.get(locToCheck)).item.type.category != ResearchSubCategory.SPACESHIPS_FIGHTERS) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    boolean isPassable(Location loc, WarUnit unit) {
+        SpacewarStructure sws = (SpacewarStructure) unit;
+        if (sws.item.type.category == ResearchSubCategory.SPACESHIPS_FIGHTERS) {
+            return isPassableForFighter(loc, unit);
+        } else {
+            boolean ip = isPassableForCapitalShip(loc, unit);
+            return ip;
+        }
+    }
+
+    /**
+     * Returns a pathfinding used by fighter typed ships.
+     * @param unit the unit doing the pathfinding
+     * @return the pathfinding object
+     */
+    Pathfinding getFighterPathfinding(final WarUnit unit) {
+        Pathfinding pathfinding = new Pathfinding();
+        pathfinding.isPassable = new Func1<Location, Boolean>() {
+            @Override
+            public Boolean invoke(Location value) {
+                return isPassableForFighter(value, unit);
+            }
+        };
+        pathfinding.isBlocked = new Func1<Location, Boolean>() {
+            @Override
+            public Boolean invoke(Location value) {
+                return isBlocked(value, unit);
+            }
+        };
+        pathfinding.distance = pathingDistance;
+        return pathfinding;
+    }
+
+    boolean isPassableForFighter(Location loc, WarUnit unit) {
+        return super.isPassable(loc, unit);
+    }
+
+    /**
+     * Returns a pathfinding used by capital ships(battleships cruisers destroyers etc.).
+     * @param unit the unit doing the pathfinding
+     * @return the pathfinding object
+     */
+    Pathfinding getCapShipPathfinding(final WarUnit unit) {
+        Pathfinding pathfinding = new Pathfinding();
+        pathfinding.isPassable = new Func1<Location, Boolean>() {
+            @Override
+            public Boolean invoke(Location value) {
+                return isPassableForCapitalShip(value, unit);
+            }
+        };
+        pathfinding.isBlocked = new Func1<Location, Boolean>() {
+            @Override
+            public Boolean invoke(Location value) {
+                return isBlocked(value, unit);
+            }
+        };
+        pathfinding.distance = pathingDistance;
+        return pathfinding;
+    }
+
+    boolean isPassableForCapitalShip(Location loc, WarUnit unit) {
+        boolean ip = super.isPassable(loc, unit);
+        if (!ip) {
+            return false;
+        }
+        for (Location neighbor : loc.getListOfNeighbors()) {
+            Set<WarUnit> wunits = unitsForPathfinding.get(neighbor);
+            if (wunits == null) {
+                continue;
+            }
+            if (wunits.isEmpty()) {
+                continue;
+            }
+            boolean isFighter = false;
+            for (WarUnit u : wunits) {
+                isFighter = ((SpacewarStructure)u).item.type.category == ResearchSubCategory.SPACESHIPS_FIGHTERS;
+            }
+            if (isFighter) {
+                continue;
+            }
+            if (!super.isPassable(neighbor, unit)) {
+                return false;
+            }
+        }
+        return ip;
+    }
+}

--- a/src/hu/openig/mechanics/WarMovementHandler.java
+++ b/src/hu/openig/mechanics/WarMovementHandler.java
@@ -28,6 +28,9 @@ public abstract class WarMovementHandler {
         this.cellSize = cellSize;
         this.simulationDelay = simulationDelay;
     }
+    /** Initialize units managed by this movement handler.
+     * */
+    public abstract void initUnits();
     /** Remove a unit handled by the movement handler object.
      * @param unit the unit to remove
      * */

--- a/src/hu/openig/model/BattleSpaceLayout.java
+++ b/src/hu/openig/model/BattleSpaceLayout.java
@@ -8,6 +8,7 @@
 
 package hu.openig.model;
 
+import java.awt.geom.Point2D;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -151,8 +152,15 @@ public class BattleSpaceLayout {
         workingHeight = referenceHeight;
         workingWidth = (int)Math.floor(getWidth() * ratio);
         Map<Location, ResearchSubCategory> newMap = new HashMap<>();
+        Point2D centerPoint = new Point2D.Double((getRightmostX()) / 2.0 , (image.getHeight()) / 2.0);
+        Point2D newCenterPoint = new Point2D.Double(centerPoint.getX() * ratio , centerPoint.getY() * ratio);
         for (Location loc : map.keySet()) {
-            newMap.put(Location.of((int)Math.round(loc.x * ratio), (int)Math.round(loc.y * ratio)), map.get(loc));
+            double scaledYpoint = (loc.y - centerPoint.getY()) * ratio + newCenterPoint.getY();
+            int newYpoint = (int) (Math.round(scaledYpoint) == Math.round(newCenterPoint.getY()) ? Math.round(scaledYpoint) : (scaledYpoint > newCenterPoint.getY() ? Math.ceil(scaledYpoint) : Math.floor(scaledYpoint)));
+            double scaledXpoint = (loc.x - centerPoint.getX()) * ratio + newCenterPoint.getX();
+            int newXpoint = (int) (Math.round(scaledXpoint) == Math.round(newCenterPoint.getX()) ? Math.round(scaledXpoint) : (scaledXpoint > newCenterPoint.getX() ? Math.ceil(scaledXpoint) : Math.floor(scaledXpoint)));
+            Location newLocation = Location.of(newXpoint, newYpoint);
+            newMap.put(newLocation, map.get(loc));
         }
         map = newMap;
     }

--- a/src/hu/openig/screen/items/PlanetScreen.java
+++ b/src/hu/openig/screen/items/PlanetScreen.java
@@ -376,6 +376,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                     doAddGuns();
                     doAddUnits();
                     movementHandler = new GroundWarMovementHandler(commons.pool, 28, SIMULATION_DELAY, units, surface().width, surface().height, surface().placement);
+                    movementHandler.initUnits();
                     planet().allocation = ResourceAllocationStrategy.BATTLE;
                     startBattle.visible(false);
                     simulator = commons.register(SIMULATION_DELAY, new Action0() {
@@ -4726,7 +4727,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
             u.lastX = u.x;
             u.lastY = u.y;
             if (u.hasPlannedMove) {
-                if (movementHandler.moveUnit(u)) {
+                if (movementHandler.moveUnit(u) && u.advanceOnUnit == null && u.advanceOnBuilding == null && !u.hasValidTarget()) {
                     u.guard = true;
                 }
                 //                if (u.nextMove == null) {
@@ -5756,7 +5757,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                     ) {
                 move(u, lm.x, lm.y);
                 u.attackMove = lm;
-                u.guard = true;
+                u.guard = false;
                 attacked = true;
             }
         }
@@ -6196,6 +6197,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
         world().scripting.onGroundwarStart(this);
 
         movementHandler = new GroundWarMovementHandler(commons.pool, 28, SIMULATION_DELAY, units, surface().width, surface().height, surface().placement);
+        movementHandler.initUnits();
         commons.simulation.resume();
     }
     /**
@@ -6416,7 +6418,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
      */
     public void attackMove(GroundwarUnit u, int x, int y) {
         stop(u);
-        u.guard = true;
+        u.guard = false;
         Location lm = Location.of(x, y);
         u.attackMove = lm;
         movementHandler.setMovementGoal(u, lm);


### PR DESCRIPTION
Implemented larger sized ship movements in space war.
Much more permissive then the original, but still prevents ships from piling on top of each other with the occasional traffic jam included for nostalgia. This in my opinion is important to prevent weapon impact and ship explosions turning into one big lightshow when those are implemented. (My next plan)
Fighters work the same as in the SimpleSpaceWarMovementHandler.
All big ships(cruisers/battleships) occupy a 1x1 space but can't get closer then one cell to other big ships, fighters are ignored in this rule so they can move freely in the spaces between big ships.
The grid size was also increased to 25x48 allowing for more space to move around.

Updated space war layout scaling to work a bit better with the new grid size. It now tries to scale the layout relative to it's center point.

Tweaked single unit selection(no drag) on space war to be able to better selects overlapping units ie. a fighter right next to a battleship. Now it won't select both but only one, always prioritizing the smaller unit under the mouse pointer.

Fixed tanks not closing distance to target after last update that touched guard handling.