### PR TITLE
Diplomacy screen and some misc.

### DIFF
--- a/src/hu/openig/mechanics/Radar.java
+++ b/src/hu/openig/mechanics/Radar.java
@@ -250,12 +250,12 @@ public final class Radar {
      */
     static List<Planet> findPlanetsInRange(World world, double x, double y, double range) {
         List<Planet> result = new ArrayList<>();
+        double rangeSqr = range * range;
         for (Planet p : world.planets.values()) {
-            if ((x - p.x) * (x - p.x) + (y - p.y) * (y - p.y) < range * range) {
-                result.add(p);
-            }
+                if ((x - p.x) * (x - p.x) + (y - p.y) * (y - p.y) < rangeSqr) {
+                    result.add(p);
+                }
         }
-
         return result;
     }
     /**

--- a/src/hu/openig/model/Player.java
+++ b/src/hu/openig/model/Player.java
@@ -952,7 +952,7 @@ public class Player {
      * @return true if the player has been defeated
      */
     public boolean isDefeated() {
-        return ownPlanets().isEmpty();
+        return ownPlanets().isEmpty() && ownFleets().isEmpty();
     }
     /**
      * Buy one unit of the given black market inventory item and optionally

--- a/src/hu/openig/screen/CommonResources.java
+++ b/src/hu/openig/screen/CommonResources.java
@@ -749,7 +749,7 @@ public class CommonResources implements GameEnvironment {
 
             List<Player> ais = new ArrayList<>();
             for (final Player p : world.players.values()) {
-                if (p.ai != null) {
+                if (p.ai != null && !p.isDefeated()) {
                     if (prepareAI(p, wip)) {
                         ais.add(p);
                     }

--- a/src/hu/openig/screen/items/DiplomacyScreen.java
+++ b/src/hu/openig/screen/items/DiplomacyScreen.java
@@ -743,26 +743,31 @@ public class DiplomacyScreen extends WalkableScreen {
 
             if (!p2.noDiplomacy) {
                 OptionItem oi1 = new OptionItem();
+                oi1.label = "";
+                oi1.enabled = false;
                 boolean active = !p2.isDefeated();
-                if (player().offers.containsKey(p2.id) && active) {
-                    oi1.label = "!" + p2.shortName;
-                } else {
-                    oi1.label = " " + p2.shortName;
+                if (active) {
+                    if (player().offers.containsKey(p2.id)) {
+                        oi1.label = "!" + p2.shortName;
+                    } else {
+                        oi1.label = " " + p2.shortName;
+                    }
+                    oi1.userObject = p2;
+
+                    oi1.enabled = rel.full && last < now - limit;
+
+                    if (oi1.enabled && rel.wontTalk()) {
+                        rel.wontTalk(false);
+                    }
                 }
-                oi1.userObject = p2;
-
-                oi1.enabled = rel.full && last < now - limit
-
-                        && active;
-
-                if (oi1.enabled && rel.wontTalk()) {
-                    rel.wontTalk(false);
-                }
-
                 races.items.add(oi1);
 
                 OptionItem oi2 = new OptionItem();
-                oi2.label = Integer.toString((int)rel.value);
+                if (active) {
+                    oi2.label = Integer.toString((int)rel.value);
+                } else {
+                    oi2.label = "";
+                }
                 oi2.enabled = oi1.enabled;
                 stances.items.add(oi2);
             }
@@ -927,8 +932,8 @@ public class DiplomacyScreen extends WalkableScreen {
             }
 
             // paint stance matrix participants
-            int ox = 0;
-            int oy = 0;
+            int ox = 10;
+            int oy = 10;
             int dw = players.size() * cellSize;
             int dh = players.size() * cellSize;
             for (int i = 1; i <= players.size(); i++) {
@@ -938,6 +943,9 @@ public class DiplomacyScreen extends WalkableScreen {
                 int dx = ox + (i - 1) * cellSize + (cellSize - tw) / 2;
 
                 Player p = players.get(i - 1);
+                if (p.isDefeated()) {
+                    continue;
+                }
 
                 commons.text().paintTo(g2, dx, oy, textSize, p.color, n);
 
@@ -957,8 +965,14 @@ public class DiplomacyScreen extends WalkableScreen {
             int stanceHeight = 7;
             for (int i = 0; i < players.size(); i++) {
                 Player row = players.get(i);
+                if (row.isDefeated()) {
+                    continue;
+                }
                 for (int j = 0; j < players.size(); j++) {
                     Player col = players.get(j);
+                    if (col.isDefeated()) {
+                        continue;
+                    }
 
                     String stance = "-";
                     int st = -1;

--- a/src/hu/openig/screen/items/SpacewarScreen.java
+++ b/src/hu/openig/screen/items/SpacewarScreen.java
@@ -1194,6 +1194,16 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
         }
     }
     /**
+     * Remove ships that are outside the screen.
+     */
+    void removeRetreatedStructures() {
+        for (SpacewarStructure s : ships()) {
+            if (!s.intersects(0, 0, space.width, space.height)) {
+                removeStructure(s);
+            }
+        }
+    }
+    /**
      * Check if all ships of the player has left the screen?
      * @param owner the owner
 
@@ -4127,6 +4137,7 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
             askRepaint();
             return;
         }
+        removeRetreatedStructures();
 
         // chat switch to flee
         if (isEnemyFleeing != battle.enemyFlee) {
@@ -4681,8 +4692,7 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
         }
         if (/* stopRetreat.visible && */playerRetreatedBeyondScreen(player())) {
             return other;
-        } else
-        if (playerRetreatedBeyondScreen(other)) {
+        } else if (playerRetreatedBeyondScreen(other)) {
             return player();
         }
         return null;


### PR DESCRIPTION
Attempt to fix issue mentioned in #990.
Diplomacy screens should no longer show defeated players.
Existing fleets are also checked to decide if a player is defeated.
Defeated AI is no longer executed.

Retreated units in space war are immediately removed to not affect pathing.