### PR TITLE
Ground defense surrendering

### DIFF
--- a/data/de/labels.xml
+++ b/data/de/labels.xml
@@ -3151,6 +3151,10 @@
 	<entry key='traits.engineers.desc'>Fähige Ingenieure repariere Ihre Flotten auch ohne Militärraumhäfen, wenngleich auch langsamer. Zusätzlich regenerieren sich Schilde schneller zwischen Gefechten.</entry>
 	<entry key='traits.combat_engineers'>Pioniere</entry>
 	<entry key='traits.combat_engineers.desc'>Ihre Ingenieure sind fähig und mutig genug, auch während der Schlacht zu helfen. Solange Schildgeneratoren nicht zerstört sind, regenerieren sich Schilde während der Schlacht.</entry>
+    <entry key='traits.no_surrender'>No Surrender!</entry>
+    <entry key='traits.no_surrender.desc'>Your garrison forces will fight to their last breath. Defensive building will not surrender when severely damaged.</entry>
+    <entry key='traits.yes_surrender'>Defense farce</entry>
+    <entry key='traits.yes_surrender.desc'>Your garrison forces fold at the slightest breeze. Defensive building will surrender at %.0f%% damage.</entry>
 	
 	<entry key='quickresearch.cost'>Forschungskosten: %1$,d cr</entry>
 	<entry key='skirmish.tech_level_max'>Maximum:</entry>
@@ -3367,6 +3371,7 @@
 	<entry key='info.planetlist_SPACESHIP_FACTORY'>Raumschiff</entry>
 	<entry key='info.planetlist_EQUIPMENT_FACTORY'>Ausrüstung</entry>
 	<entry key='info.building_present'>vorhanden</entry>
+    <entry key='info.building_surrendered'>Surrendered</entry>
 	<entry key='info.planetlist_WEAPONS_FACTORY'>Waffen</entry>
 	<entry key='info.planetlist_BARRACKS'>Barracken</entry>
 	<entry key='info.planetlist_GUNS'>Geschütze</entry>

--- a/data/en/labels.xml
+++ b/data/en/labels.xml
@@ -3017,6 +3017,10 @@
 	<entry key='traits.engineers.desc'>Skilled engineers will repair your fleet without military spaceports, although at a much lower rate. However, your shields will regenerate faster between battles.</entry>
 	<entry key='traits.combat_engineers'>Combat engineers</entry>
 	<entry key='traits.combat_engineers.desc'>Your engineers are brave enough to help you fix and regenerate your shields during battles, so long as the shield generator isn't destroyed.</entry>
+    <entry key='traits.no_surrender'>No Surrender!</entry>
+    <entry key='traits.no_surrender.desc'>Your garrison forces will fight to their last breath. Defensive building will not surrender when severely damaged.</entry>
+    <entry key='traits.yes_surrender'>Defense farce</entry>
+    <entry key='traits.yes_surrender.desc'>Your garrison forces fold at the slightest breeze. Defensive building will surrender at %.0f%% damage.</entry>
 	<entry key='quickresearch.cost'>Research cost: %1$,d cr</entry>
 	<entry key='skirmish.tech_level_max'>Maximum:</entry>
 
@@ -3316,6 +3320,7 @@
 	<entry key='info.planetlist_SPACESHIP_FACTORY'>Spaceship</entry>
 	<entry key='info.planetlist_EQUIPMENT_FACTORY'>Equipment</entry>
 	<entry key='info.building_present'>present</entry>
+    <entry key='info.building_surrendered'>Surrendered</entry>
 	<entry key='info.planetlist_WEAPONS_FACTORY'>Weapon</entry>
 	<entry key='info.planetlist_BARRACKS'>Barracks</entry>
 	<entry key='info.planetlist_GUNS'>Guns</entry>

--- a/data/es/labels.xml
+++ b/data/es/labels.xml
@@ -370,6 +370,7 @@
 	<entry key="info.details_TRADERS_SPACEPORT">Comerciantes</entry>
 	<entry key="info.planetlist_TRADERS_SPACEPORT">Comerciantes</entry>
 	<entry key="info.building_present">presente</entry>
+	<entry key='info.building_surrendered'>Surrendered</entry>
 	<entry key="fleet">Flota %s</entry>
 	<entry key="achievement.columbus">Columbus</entry>
 	<entry key="autosave">Autoguardado</entry>
@@ -1161,6 +1162,10 @@
 	<entry key="traits.rocks_and_sticks">Rocas y palos</entry>
 	<entry key="traits.master_astronomy">Dominar la astronomía</entry>
 	<entry key="traits.combat_engineers">Ingenieros de combate</entry>
+	<entry key='traits.no_surrender'>No Surrender!</entry>
+	<entry key='traits.no_surrender.desc'>Your garrison forces will fight to their last breath. Defensive building will not surrender when severely damaged.</entry>
+	<entry key='traits.yes_surrender'>Defense farce</entry>
+	<entry key='traits.yes_surrender.desc'>Your garrison forces fold at the slightest breeze. Defensive building will surrender at %.0f%% damage.</entry>
 	<entry key="languages.en">English / Inglés</entry>
 	<entry key="languages.fr">French / Francés</entry>
 	<entry key="skirmish.tax_base">Base imponible:</entry>

--- a/data/fr/labels.xml
+++ b/data/fr/labels.xml
@@ -1903,6 +1903,7 @@
   <entry key='hide_objectives'>Appuyez sur TAB pour montrer/cacher les objectifs.</entry>
   <entry key='incoming_message'>- Message -</entry>
   <entry key='info.building_present'>Présent</entry>
+  <entry key='info.building_surrendered'>Surrendered</entry>
   <entry key='info.details_BANK'>Banque</entry>
   <entry key='info.details_BARRACKS'>Baraquement</entry>
   <entry key='info.details_EQUIPMENT_FACTORY'>Us. d&#39;equi.</entry>

--- a/data/generic/campaign/main/players.xml
+++ b/data/generic/campaign/main/players.xml
@@ -106,6 +106,9 @@
 			<type id='GarthogDestroyer' list=''/>
 			<type id='GarthogBattleship' list=''/>
 		</available>
+		<traits>
+			<trait id='NoSurrender'/>
+		</traits>
 	</player>
 	<player id='Morgath' race='morgath' name='players.morgath'
 		icon='starmap/fleets/morgath_fleet'
@@ -207,6 +210,9 @@
 			<type id='SullepDestroyer' list=''/>
 			<type id='SullepBattleship' list=''/>
 		</available>
+		<traits>
+			<trait id='NoSurrender'/>
+		</traits>
 	</player>
 	<player id='Dargslan' race='dargslan' name='players.dargslan'
 		icon='starmap/fleets/dargslan_fleet'
@@ -239,6 +245,9 @@
 			<type id='DargslanDestroyer' list=''/>
 			<type id='DargslanBattleship' list=''/>
 		</available>
+		<traits>
+			<trait id='NoSurrender'/>
+		</traits>
 	</player>
 	<player id='Ecalep' race='ecalep' name='players.ecalep'
 		icon='starmap/fleets/ecalep_fleet'

--- a/data/generic/campaign/main2/players.xml
+++ b/data/generic/campaign/main2/players.xml
@@ -139,6 +139,9 @@
 			<type id='IonCannon' list=''/>
 			<type id='ColonyShip' list=''/>
 		</available>
+		<traits>
+			<trait id='NoSurrender'/>
+		</traits>
 		<!-- 
 		<fleet id='-1' x='366' y='442' name='Garthog flotta'>
 			<item id='-1' type='GarthogBattleship' count='1'/>
@@ -237,6 +240,9 @@
 			<type id='MediumTank' list=''/>
 			<type id='RocketLauncher1' list=''/>
 		</available>
+		<traits>
+			<trait id='NoSurrender'/>
+		</traits>
 	</player>
 	<player id='Dargslan' race='dargslan' name='players.dargslan'
 		icon='starmap/fleets/dargslan_fleet'
@@ -263,6 +269,9 @@
 			<type id='HeavyTank' list=''/>
 			<type id='RocketLauncher2' list=''/>
 		</available>
+		<traits>
+			<trait id='NoSurrender'/>
+		</traits>
 	</player>
 	<player id='Ecalep' race='ecalep' name='players.ecalep'
 		icon='starmap/fleets/ecalep_fleet'

--- a/data/generic/traits.xml
+++ b/data/generic/traits.xml
@@ -227,4 +227,22 @@
 		cost='4'
 	>
 	</trait>
+	<trait
+			id='NoSurrender'
+			kind='SURRENDER'
+			label='traits.no_surrender'
+			description='traits.no_surrender.desc'
+			cost='0'
+			value='0'
+	>
+	</trait>
+	<trait
+			id='YesSurrender'
+			kind='SURRENDER'
+			label='traits.yes_surrender'
+			description='traits.yes_surrender.desc'
+			cost='-1'
+			value='50'
+	>
+	</trait>
 </traits>

--- a/data/hu/labels.xml
+++ b/data/hu/labels.xml
@@ -3062,6 +3062,10 @@
 	<entry key='traits.engineers.desc'>Képzett mérnökök kijavítják a hajódat már a bolygóközi térben, de sokkal lassabban, mint egy katonai űrkikötővel rendelkező bolygón. Viszont a pajzs sokkal gyorsabban regenerálódik két csata között.</entry>
 	<entry key='traits.combat_engineers'>Harci mérnökök</entry>
 	<entry key='traits.combat_engineers.desc'>A mérnökeid elég bátrak, hogy csata közben is javítsák a hajód pajzsaid, feltéve hogy nem semmisült meg a pajzsgenerátor.</entry>
+	<entry key='traits.no_surrender'>Nincs visszavonulás!</entry>
+	<entry key='traits.no_surrender.desc'>Bolygó védelmi erőid a végsőkig harcolnak. Erődítményeid nem kapitulálnak súlyos sérülés esetén.</entry>
+	<entry key='traits.yes_surrender'>Visszavonulás!</entry>
+	<entry key='traits.yes_surrender.desc'>Bolygó védelmi erőid a legkisebb ellenállás láttán menekülőre fogják. Erődítményeid %.0f%% sérülésnél kapitulálnak.</entry>
 	<entry key='quickresearch.cost'>Kutatási költség: %1$,d cr</entry>
 	<entry key='skirmish.tech_level_max'>Maximum:</entry>
 	<entry key='planets.Achilles'>Achilles</entry>
@@ -3352,6 +3356,7 @@
 	<entry key='info.planetlist_SPACESHIP_FACTORY'>Űrhajógyár</entry>
 	<entry key='info.planetlist_EQUIPMENT_FACTORY'>Felsz.gyár</entry>
 	<entry key='info.building_present'>van</entry>
+	<entry key='info.building_surrendered'>Kapitulált</entry>
 	<entry key='info.planetlist_WEAPONS_FACTORY'>Fegyv.gyár</entry>
 	<entry key='info.planetlist_BARRACKS'>Laktanyák</entry>
 	<entry key='info.planetlist_GUNS'>Ágyúk</entry>

--- a/data/ru/labels.xml
+++ b/data/ru/labels.xml
@@ -3072,6 +3072,10 @@
   <entry key='traits.weapon_mastery.desc'>Повреждения, наносимые в бою противнику увечены на %.0f%%.</entry>
   <entry key='traits.weapon_mocker'>Низкая скорость производства оружия</entry>
   <entry key='traits.weapon_mocker.desc'>Скорость производства оружия уменьшена на %.0f%%.</entry>
+  <entry key='traits.no_surrender'>No Surrender!</entry>
+  <entry key='traits.no_surrender.desc'>Your garrison forces will fight to their last breath. Defensive building will not surrender when severely damaged.</entry>
+  <entry key='traits.yes_surrender'>Defense farce</entry>
+  <entry key='traits.yes_surrender.desc'>Your garrison forces fold at the slightest breeze. Defensive building will surrender at %.0f%% damage.</entry>
   <entry key='videos.all_videos'>Все видеоролики</entry>
   <entry key='videos.back'>Назад</entry>
   <entry key='videos.name'>Название</entry>
@@ -3332,6 +3336,7 @@
 	<entry key='info.planetlist_SPACESHIP_FACTORY'>Spaceship</entry>
 	<entry key='info.planetlist_EQUIPMENT_FACTORY'>Equipment</entry>
 	<entry key='info.building_present'>present</entry>
+    <entry key='info.building_surrendered'>Surrendered</entry>
 	<entry key='info.planetlist_WEAPONS_FACTORY'>Weapon</entry>
 	<entry key='info.planetlist_BARRACKS'>Barracks</entry>
 	<entry key='info.planetlist_GUNS'>Guns</entry>

--- a/dlc/gump891202-racemod-0.1/hu/skirmish/racemod-0.1/labels.xml
+++ b/dlc/gump891202-racemod-0.1/hu/skirmish/racemod-0.1/labels.xml
@@ -3173,6 +3173,10 @@
 	<entry key='traits.engineers.desc'>Képzett mérnökök kijavítják a hajódat már a bolygóközi térben, de sokkal lassabban, mint egy katonai űrkikötővel rendelkező bolygón. Viszont a pajzs sokkal gyorsabban regenerálódik két csata között.</entry>
 	<entry key='traits.combat_engineers'>Harci mérnökök</entry>
 	<entry key='traits.combat_engineers.desc'>A mérnökeid elég bátrak, hogy csata közben is javítsák a hajód pajzsaid, feltéve hogy nem semmisült meg a pajzsgenerátor.</entry>
+	<entry key='traits.no_surrender'>Nincs visszavonulás!</entry>
+	<entry key='traits.no_surrender.desc'>Bolygó védelmi erőid a végsőkig harcolnak. Erődítményeid nem kapitulálnak súlyos sérülés esetén.</entry>
+	<entry key='traits.yes_surrender'>Visszavonulás!</entry>
+	<entry key='traits.yes_surrender.desc'>Bolygó védelmi erőid a legkisebb ellenállás láttán menekülőre fogják. Erődítményeid %.0f%% sérülésnél kapitulálnak.</entry>
 	<entry key='quickresearch.cost'>Kutatási költség: %1$,d cr</entry>
 	<entry key=""></entry>
 	<entry key=""></entry>

--- a/src/hu/openig/GameWindow.java
+++ b/src/hu/openig/GameWindow.java
@@ -89,6 +89,7 @@ import hu.openig.model.Screens;
 import hu.openig.model.SkirmishDefinition;
 import hu.openig.model.SoundTarget;
 import hu.openig.model.SoundType;
+import hu.openig.model.TraitKind;
 import hu.openig.model.World;
 import hu.openig.screen.CommonResources;
 import hu.openig.screen.GameControls;
@@ -1821,8 +1822,8 @@ public class GameWindow extends JFrame implements GameControls {
                 }
                 // check surface for defensive structures
                 for (Building b : bi.targetPlanet.surface.buildings.iterable()) {
-                    if (b.isOperational() && "Defensive".equals(b.type.kind)) {
-                        groundBattle = true;
+                    if (b.isComplete() && "Defensive".equals(b.type.kind)) {
+                        groundBattle |= !BattleSimulator.buildingShouldSurrender(b, bi.targetPlanet.owner.traits.trait(TraitKind.SURRENDER));
                     }
                     if (b.isOperational() && "Gun".equals(b.type.kind)) {
                         spaceBattle = true;

--- a/src/hu/openig/mechanics/BattleSimulator.java
+++ b/src/hu/openig/mechanics/BattleSimulator.java
@@ -32,6 +32,8 @@ import hu.openig.model.ResearchSubCategory;
 import hu.openig.model.ResearchType;
 import hu.openig.model.SpaceStrengths;
 import hu.openig.model.SpacewarStructure;
+import hu.openig.model.Trait;
+import hu.openig.model.TraitKind;
 import hu.openig.model.World;
 import hu.openig.utils.U;
 
@@ -948,11 +950,32 @@ public final class BattleSimulator {
             return true;
         }
         for (Building b : planet.surface.buildings.iterable()) {
-            if (b.isOperational() && b.type.kind.equals("Defensive")) {
-                return true;
+            if (b.isComplete() && b.type.kind.equals("Defensive")) {
+                if (!buildingShouldSurrender(b, planet.owner.traits.trait(TraitKind.SURRENDER))) {
+                    return true;
+                }
             }
         }
         return false;
+    }
+    /**
+     * @param building the building to check
+     * @param t the trait affecting surrender
+
+     * @return true if the building in question should surrender.
+
+     */
+    public static boolean buildingShouldSurrender(Building building, Trait t) {
+        double surrenderThreshold = 90;
+        if (t != null &&  t.kind == TraitKind.SURRENDER) {
+            surrenderThreshold = t.value;
+        }
+        if (surrenderThreshold == 0) {
+            return false;
+        } else if (building.hitpoints > building.type.hitpoints * ((100 - surrenderThreshold) / 100)) {
+            return false;
+        }
+        return true;
     }
     /**
      * Check if the planet has bunker.

--- a/src/hu/openig/model/TraitKind.java
+++ b/src/hu/openig/model/TraitKind.java
@@ -42,5 +42,7 @@ public enum TraitKind {
     /** Regenerate shields faster, repair ships without military spaceport. */
     ENGINEERS,
     /** Regenerate shields during combat. */
-    COMBAT_ENGINEERS
+    COMBAT_ENGINEERS,
+    /** Groundwar fortifications surrender rate. */
+    SURRENDER
 }


### PR DESCRIPTION
Reworked groundwar defensive building behaviour.
Unpowered forts should still fire with half their guns, same for building with >50% damage.
Defensive buildings that are unpowered and/or damaged above the surrender threshold will still invoke a ground battle.
Un-powering forts no longer cause instant victory.
By default all defensive building should now surrender at 90% damage.
Added traits that change when a building surrenders.
  - No surrender! - self explanatory
  - Defense farce - building surrender at 50%, similar to how it behaved before this.
Added new 'No surrender!' trait to sullep, dargslan and garthog players in the main campaign to be in line with how the original races worked. Only new games will take these traits into account.

Should resolve #576