### PR TITLE
Fixed explosion animation causing slowdown

### DIFF
--- a/src/hu/openig/core/Location.java
+++ b/src/hu/openig/core/Location.java
@@ -105,16 +105,16 @@ public final class Location {
     public List<Location> getListOfNeighbors() {
 
         if (neighbors == null) {
-            neighbors = new ArrayList<>(8);
-            neighbors.add(delta(-1, 0));
-            neighbors.add(delta(1, 0));
-            neighbors.add(delta(0, 1));
-            neighbors.add(delta(0, -1));
-            neighbors.add(delta(-1, -1));
-            neighbors.add(delta(-1, 1));
-            neighbors.add(delta(1, -1));
-            neighbors.add(delta(1, 1));
-            neighbors = Collections.unmodifiableList(neighbors);
+            List<Location> neighborsList = new ArrayList<>(8);
+            neighborsList.add(delta(-1, 0));
+            neighborsList.add(delta(1, 0));
+            neighborsList.add(delta(0, 1));
+            neighborsList.add(delta(0, -1));
+            neighborsList.add(delta(-1, -1));
+            neighborsList.add(delta(-1, 1));
+            neighborsList.add(delta(1, -1));
+            neighborsList.add(delta(1, 1));
+            neighbors = Collections.unmodifiableList(neighborsList);
         }
         return neighbors;
     }


### PR DESCRIPTION
Fixed destroyed space war units removed multiple times when multiple fatal shots hit a target before it got removed with the explosion animation.
Fixed concurrency exception when using cached neighbor locations.

Renamed a variable around rocket handling.