### PR TITLE
Updated groundwar planet surface rendering

### DIFF
--- a/src/hu/openig/gfx/ColonyGFX.java
+++ b/src/hu/openig/gfx/ColonyGFX.java
@@ -57,7 +57,7 @@ public class ColonyGFX {
     /** The tile crossed. */
     @Img(name = "colony/tile_1x1_selected_crossed")
     public BufferedImage tileCrossed;
-    /** The tile crossed. */
+    /** The tile paved. */
     @Img(name = "colony/tile_1x1_pavement")
     public BufferedImage tilePavement;
     /** Upgrade panel. */

--- a/src/hu/openig/model/PlanetSurface.java
+++ b/src/hu/openig/model/PlanetSurface.java
@@ -1116,6 +1116,14 @@ public class PlanetSurface {
             return (surfaceArray[getArrayIndexForLocation(x, y)] & CROSSROAD) != 0;
         }
         /**
+         * Check if a location has building on it.
+         * @param loc the location
+         * @return true if surface tile has building on it
+         */
+        public boolean hasBuilding(Location loc) {
+            return (surfaceArray[getArrayIndexForLocation(loc.x, loc.y)] & BUILDING) != 0;
+        }
+        /**
          * Check if a cell is buildable.
          * @param x the X coordinate
          * @param y the Y coordinate


### PR DESCRIPTION
A "quick" and mostly dirty commit addressing #1163 

 - Surface and radar minimap are drawn into a buffered image that is then drawn to the screen. The images are redrawn only in case of an event that changes the visual appearance of the planet surface.
 - Radar minimap is transformed to a proper rectangle,  leveled it horizontal and added an orange rectangle as a frame to resemble the og ig minimap.

After this on my laptop I saw the frame times being halved.
For the time being the battle and non-battle rendering codes are separated. I intend to have this on the non-battle colony screen as well to at least make the code not this ugly. For that I need to implement some system to notify the render that a colony state change happened that warrants a visual update. ie. night time happening, or construction scaffolding updates and such.