### PR TITLE
Improved the rectangular transformation of the surface radar

### DIFF
--- a/src/hu/openig/model/Tile.java
+++ b/src/hu/openig/model/Tile.java
@@ -279,6 +279,42 @@ public class Tile {
         return -12 * x - 15 * y;
     }
     /**
+     * Converts the tile coordinates to pixel coordinates on the radar map, X component.
+     * @param x the X tile coordinate
+     * @param y the Y tile coordinate
+     * @return the screen coordinate
+     */
+    public static int toRadarX(int x, int y) {
+        return x * 28 - y * 28;
+    }
+    /**
+     * Converts the tile coordinates to pixel coordinates on the radar map, Y component.
+     * @param x the X tile coordinate
+     * @param y the Y tile coordinate
+     * @return the screen Y coordinate
+     */
+    public static int toRadarY(int x, int y) {
+        return -12 * x - 12 * y;
+    }
+    /**
+     * Converts the tile coordinates to pixel coordinates on the radar map, X component.
+     * @param x the X tile coordinate
+     * @param y the Y tile coordinate
+     * @return the screen coordinate
+     */
+    public static double toRadarX(double x, double y) {
+        return x * 28 - y * 28;
+    }
+    /**
+     * Converts the tile coordinates to pixel coordinates on the radar map, Y component.
+     * @param x the X tile coordinate
+     * @param y the Y tile coordinate
+     * @return the screen Y coordinate
+     */
+    public static double toRadarY(double x, double y) {
+        return -12 * x - 12 * y;
+    }
+    /**
      * Converts the screen coordinates to tile coordinates, X component.
      * @param x the X screen coordinate
      * @param y the Y screen coordinate


### PR DESCRIPTION
I realized my previous rotating/shearing method to make the radar minimap look rectangular introduced a set of problems with the selection and viewport boxes, and UI scaling. To fix this, the image is now drawn using rectangular tile coordinates which in the end, results in a rectangular minimap image but done a bit faster without all the transformation overhead.

This also made it possible to fit it better into the UI minimap panel and so I removed the yellow frame as it now looks out of place.

<img width="333" height="240" alt="image" src="https://github.com/user-attachments/assets/ce153950-c7f1-4dfa-ba6b-0c0eb2d3b854" />

<img width="313" height="237" alt="image" src="https://github.com/user-attachments/assets/55065c92-0f94-4db2-97af-acbe9da70fed" />
