### PR TITLE
Tweak large Tile striping

### DIFF
--- a/src/hu/openig/editors/MapRenderer.java
+++ b/src/hu/openig/editors/MapRenderer.java
@@ -255,7 +255,7 @@ public class MapRenderer extends JComponent {
         g2.setColor(Color.YELLOW);
         g2.drawRect(br.x, br.y, br.width, br.height);
 
-        BufferedImage empty = areaEmpty.getStrip(0);
+        BufferedImage empty = areaEmpty.getStrip(0).image;
         Rectangle renderingWindow = new Rectangle(0, 0, getWidth(), getHeight());
         for (int i = 0; i < surface.renderingOrigins.size(); i++) {
             Location loc = surface.renderingOrigins.get(i);
@@ -287,7 +287,7 @@ public class MapRenderer extends JComponent {
                 if (!surface.placement.canPlaceBuilding(loc.x, loc.y)) {
                     int x = x0 + Tile.toScreenX(loc.x, loc.y);
                     int y = y0 + Tile.toScreenY(loc.x, loc.y);
-                    g2.drawImage(areaDeny.getStrip(0), x, y, null);
+                    g2.drawImage(areaDeny.getStrip(0).image, x, y, null);
                 }
             }
         }
@@ -297,24 +297,24 @@ public class MapRenderer extends JComponent {
                     for (int j = selectedRectangle.y; j > selectedRectangle.y - selectedRectangle.height; j--) {
                         int x = x0 + Tile.toScreenX(i, j);
                         int y = y0 + Tile.toScreenY(i, j);
-                        g2.drawImage(selection.getStrip(0), x, y, null);
+                        g2.drawImage(selection.getStrip(0).image, x, y, null);
                     }
                 }
             }
             if (current != null) {
                 int x = x0 + Tile.toScreenX(current.x, current.y);
                 int y = y0 + Tile.toScreenY(current.x, current.y);
-                g2.drawImage(areaCurrent.getStrip(0), x, y, null);
+                g2.drawImage(areaCurrent.getStrip(0).image, x, y, null);
             }
         } else
         if (placementRectangle.width > 0) {
             for (int i = placementRectangle.x; i < placementRectangle.x + placementRectangle.width; i++) {
                 for (int j = placementRectangle.y; j > placementRectangle.y - placementRectangle.height; j--) {
 
-                    BufferedImage img = areaAccept.getStrip(0);
+                    BufferedImage img = areaAccept.getStrip(0).image;
                     // check for existing building
                     if (!surface.placement.canPlaceBuilding(i, j)) {
-                        img = areaDeny.getStrip(0);
+                        img = areaDeny.getStrip(0).image;
                     }
 
                     int x = x0 + Tile.toScreenX(i, j);
@@ -459,14 +459,19 @@ public class MapRenderer extends JComponent {
             cell.yCompensation = 27 - se.tile.imageHeight;
             cell.a = loc1.x - se.virtualColumn;
             cell.b = loc1.y + se.virtualRow - se.tile.height + 1;
+            Tile.ImageStrip strip;
             if (se.virtualColumn == 0 && se.virtualRow < se.tile.height) {
                 se.tile.alpha = alpha;
-                cell.image = se.tile.getStrip(se.virtualRow);
+                strip = se.tile.getStrip(se.virtualRow);
+                cell.image = strip.image;
+                cell.yCompensation += strip.yOffset;
                 return;
             } else
             if (se.virtualRow == se.tile.height - 1) {
                 se.tile.alpha = alpha;
-                cell.image = se.tile.getStrip(se.tile.height - 1 + se.virtualColumn);
+                strip = se.tile.getStrip(se.tile.height - 1 + se.virtualColumn);
+                cell.image = strip.image;
+                cell.yCompensation += strip.yOffset;
                 return;
             }
             cell.image = null;
@@ -496,7 +501,7 @@ public class MapRenderer extends JComponent {
             }
 
             cell.yCompensation = 27 - tile.imageHeight;
-            cell.image = tile.getStrip(0);
+            cell.image = tile.getStrip(0).image;
             cell.a = loc1.x;
             cell.b = loc1.y;
 
@@ -513,7 +518,7 @@ public class MapRenderer extends JComponent {
             }
             cell.yCompensation = 27 - tile.imageHeight;
             tile.alpha = alpha;
-            cell.image = tile.getStrip(0);
+            cell.image = tile.getStrip(0).image;
             cell.a = loc1.x;
             cell.b = loc1.y;
         } else {
@@ -531,14 +536,19 @@ public class MapRenderer extends JComponent {
             cell.yCompensation = 27 - tile.imageHeight;
             cell.a = loc1.x - se.virtualColumn;
             cell.b = loc1.y + se.virtualRow - se.tile.height + 1;
+            Tile.ImageStrip strip;
             if (se.virtualColumn == 0 && se.virtualRow < se.tile.height) {
                 tile.alpha = alpha;
-                cell.image = tile.getStrip(se.virtualRow);
+                strip = tile.getStrip(se.virtualRow);
+                cell.image = strip.image;
+                cell.yCompensation += strip.yOffset;
                 return;
             } else
             if (se.virtualRow == se.tile.height - 1) {
                 tile.alpha = alpha;
-                cell.image = tile.getStrip(se.tile.height - 1 + se.virtualColumn);
+                strip = tile.getStrip(se.tile.height - 1 + se.virtualColumn);
+                cell.image = strip.image;
+                cell.yCompensation += strip.yOffset;
                 return;
             }
             cell.image = null;

--- a/src/hu/openig/model/TileCached.java
+++ b/src/hu/openig/model/TileCached.java
@@ -19,7 +19,7 @@ import java.util.Map;
  */
 public class TileCached extends Tile {
     /** The cached image strips. The key is maxCount times the alpha value. */
-    protected final Map<Integer, Ref<BufferedImage[]>> cache = new HashMap<>();
+    protected final Map<Integer, Ref<ImageStrip[]>> cache = new HashMap<>();
     /** The maximum alpha cache count. */
     protected final int maxCount;
     /**
@@ -48,12 +48,12 @@ public class TileCached extends Tile {
         return new TileCached(this);
     }
     @Override
-    public BufferedImage getStrip(int stripIndex) {
+    public ImageStrip getStrip(int stripIndex) {
         if (hasAlphaChanged()) {
             float a = (Math.min(Math.max(MIN_ALPHA, alpha), 1f) - MIN_ALPHA) / (1f - MIN_ALPHA);
             int key = (int)(a * maxCount + 0.5);
-            Ref<BufferedImage[]> r = cache.get(key);
-            BufferedImage[] strips = r != null ? r.get() : null;
+            Ref<ImageStrip[]> r = cache.get(key);
+            ImageStrip[] strips = r != null ? r.get() : null;
             if (r == null || strips == null) {
                 renew();
                 computeImageWithLights();
@@ -69,14 +69,15 @@ public class TileCached extends Tile {
      * Create a fresh image in place of every array element.
      */
     protected void renew() {
-        BufferedImage[] newStrips = new BufferedImage[stripCache.length];
+        ImageStrip[] newStrips = new ImageStrip[stripCache.length];
         for (int i = 0; i < newStrips.length; i++) {
-            BufferedImage s = stripCache[i];
-            final int w = s.getWidth();
-            final int h = s.getHeight();
+            ImageStrip s = stripCache[i];
+            final int w = s.image.getWidth();
+            final int h = s.image.getHeight();
             BufferedImage d = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
             d.setAccelerationPriority(1.0f);
-            newStrips[i] = d;
+            newStrips[i].yOffset = s.yOffset;
+            newStrips[i].image = d;
         }
         stripCache = newStrips;
     }

--- a/src/hu/openig/screen/items/PlanetScreen.java
+++ b/src/hu/openig/screen/items/PlanetScreen.java
@@ -696,14 +696,19 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
             cell.yCompensation = 27 - se.tile.imageHeight;
             cell.a = loc1.x - se.virtualColumn;
             cell.b = loc1.y + se.virtualRow - se.tile.height + 1;
+            Tile.ImageStrip strip;
             if (se.virtualColumn == 0 && se.virtualRow < se.tile.height) {
                 se.tile.alpha = alpha;
-                cell.image = se.tile.getStrip(se.virtualRow);
+                strip = se.tile.getStrip(se.virtualRow);
+                cell.image = strip.image;
+                cell.yCompensation += strip.yOffset;
                 return;
             } else
             if (se.virtualRow == se.tile.height - 1) {
                 se.tile.alpha = alpha;
-                cell.image = se.tile.getStrip(se.tile.height - 1 + se.virtualColumn);
+                strip = se.tile.getStrip(se.tile.height - 1 + se.virtualColumn);
+                cell.image = strip.image;
+                cell.yCompensation += strip.yOffset;
                 return;
             }
             cell.image = null;
@@ -735,7 +740,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
             }
 
             cell.yCompensation = 27 - tile.imageHeight;
-            cell.image = tile.getStrip(0);
+            cell.image = tile.getStrip(0).image;
             cell.a = loc1.x;
             cell.b = loc1.y;
 
@@ -745,7 +750,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
             Tile tile =  se.building.scaffolding.normal.get(0);
             cell.yCompensation = 27 - tile.imageHeight;
             tile.alpha = alpha;
-            cell.image = tile.getStrip(0);
+            cell.image = tile.getStrip(0).image;
             cell.a = loc1.x;
             cell.b = loc1.y;
             return;
@@ -774,7 +779,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
 
             cell.yCompensation = 27 - tile.imageHeight;
             tile.alpha = alpha;
-            cell.image = tile.getStrip(0);
+            cell.image = tile.getStrip(0).image;
             cell.a = loc1.x;
             cell.b = loc1.y;
         } else {
@@ -791,14 +796,19 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
             cell.yCompensation = 27 - tile.imageHeight;
             cell.a = loc1.x - se.virtualColumn;
             cell.b = loc1.y + se.virtualRow - se.tile.height + 1;
+            Tile.ImageStrip strip;
             if (se.virtualColumn == 0 && se.virtualRow < se.tile.height) {
                 tile.alpha = alpha;
-                cell.image = tile.getStrip(se.virtualRow);
+                strip = tile.getStrip(se.virtualRow);
+                cell.image = strip.image;
+                cell.yCompensation += strip.yOffset;
                 return;
             } else
             if (se.virtualRow == se.tile.height - 1) {
                 tile.alpha = alpha;
-                cell.image = tile.getStrip(se.tile.height - 1 + se.virtualColumn);
+                strip = tile.getStrip(se.tile.height - 1 + se.virtualColumn);
+                cell.image = strip.image;
+                cell.yCompensation += strip.yOffset;
                 return;
             }
             cell.image = null;
@@ -1367,7 +1377,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                     for (Location loc : battlePlacements) {
                         int x = x0 + Tile.toScreenX(loc.x, loc.y);
                         int y = y0 + Tile.toScreenY(loc.x, loc.y);
-                        g2.drawImage(areaDeploy.getStrip(0), x, y, null);
+                        g2.drawImage(areaDeploy.getStrip(0).image, x, y, null);
                     }
                 }
                 if (placementMode) {
@@ -1375,10 +1385,10 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                         for (int i = placementRectangle.x; i < placementRectangle.x + placementRectangle.width; i++) {
                             for (int j = placementRectangle.y; j > placementRectangle.y - placementRectangle.height; j--) {
 
-                                BufferedImage img = areaAccept.getStrip(0);
+                                BufferedImage img = areaAccept.getStrip(0).image;
                                 // check for existing building
                                 if (!surface().placement.canPlaceBuilding(i, j)) {
-                                    img = areaDeny.getStrip(0);
+                                    img = areaDeny.getStrip(0).image;
                                 }
 
                                 int x = x0 + Tile.toScreenX(i, j);
@@ -1918,7 +1928,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                             gt.drawString(String.valueOf(movementHandler.pathWeightMap.weightMap[loc1.x + movementHandler.pathWeightMap.offsetX][loc1.y + movementHandler.pathWeightMap.offsetY]), x + 20, y + 20);
                             if (movementHandler.reservedCells.get(Location.of(loc.x - j, loc.y)) != null) {
                                 //add slight offset, so it can be seen if a tile is both reserved and taken
-                                g2.drawImage(areaReserved.getStrip(0), x, y + 5, null);
+                                g2.drawImage(areaReserved.getStrip(0).image, x, y + 5, null);
                             }
                         }
                         gt.dispose();
@@ -2206,7 +2216,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                 radarMapImage = new BufferedImage(br.width, br.height, BufferedImage.TYPE_INT_ARGB);
                 surfaceGraphics = radarMapImage.createGraphics();
             }
-            BufferedImage empty = areaEmpty.getStrip(0);
+            BufferedImage empty = areaEmpty.getStrip(0).image;
             for (int i = 0; i < surface.renderingOrigins.size(); i++) {
                 Location loc = surface.renderingOrigins.get(i);
                 for (int j = 0; j < surface.renderingLength.get(i); j++) {
@@ -4401,7 +4411,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
                 Location loc = u.location();
                 int x = surface().baseXOffset + Tile.toScreenX(loc.x, loc.y);
                 int y = surface().baseYOffset + Tile.toScreenY(loc.x, loc.y);
-                g2.drawImage(areaTaken.getStrip(0), x, y , null);
+                g2.drawImage(areaTaken.getStrip(0).image, x, y , null);
             }
             if (u.paralizedTTL > 0) {
                 // draw green paralization effect


### PR DESCRIPTION
In a attempt to reduce the number of pixels to process on the planet surface rendering, I added the following:
- Reduced the width (from 57 to 31) of strips created from the second half of the source image to remove overlapping areas.
- Added vertical trimming of transparent areas in strips.

This reduced processed pixel count by around 40-50%, when updating alpha during the night cycle. Also helps a bit with the overall rendering of the planet surface.