### PR TITLE
Fixed spacewar MovementHandler NPE

### DIFF
--- a/src/hu/openig/screen/items/SpacewarScreen.java
+++ b/src/hu/openig/screen/items/SpacewarScreen.java
@@ -1403,8 +1403,8 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
         } else {
             rightPanel.displayPanel(PanelMode.COMMUNICATOR);
             setLayoutSelectionMode(false);
-            commons.simulation.resume();
             enableFleetControls(true);
+            commons.simulation.resume();
         }
         retreat.enabled = false;
 


### PR DESCRIPTION
Fixed a race condition when starting space a space battle, where the AI ships might end up with no MovementHandler set for the first game ticks.