### PR TITLE
Fix spacewar FPS drop by reusing sound-effect audio lines

### DIFF
--- a/src/hu/openig/sound/Sounds.java
+++ b/src/hu/openig/sound/Sounds.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.sound.sampled.AudioFormat;
 import javax.sound.sampled.AudioFormat.Encoding;
@@ -189,6 +190,13 @@ public class Sounds {
      * @return the data line
      */
     SourceDataLine getLine(AudioFormatType aft) {
+        BlockingQueue<SourceDataLine> q = soundPool.get(aft);
+        if (q != null) {
+            SourceDataLine sdl = q.poll();
+            if (sdl != null) {
+                return sdl;
+            }
+        }
         return addLine(aft);
     }
     /**
@@ -197,7 +205,24 @@ public class Sounds {
      * @param sdl the source data line
      */
     void putBackLine(AudioFormatType aft, SourceDataLine sdl) {
-        sdl.close();
+        try {
+            sdl.stop();
+        } catch (Throwable t) {
+            // ignored
+        }
+        try {
+            sdl.flush();
+        } catch (Throwable t) {
+            // ignored
+        }
+        BlockingQueue<SourceDataLine> q = soundPool.get(aft);
+        if (q != null && q.offer(sdl)) {
+            return;
+        }
+        synchronized (this) {
+            sdl.close();
+            lines.remove(sdl);
+        }
     }
     /** Close all audio lines. */
     public void close() {
@@ -254,58 +279,85 @@ public class Sounds {
         if (vol > 0) {
             if (effectSemaphore.tryAcquire()) {
                 try {
-
                     final byte[] data = soundMap.get(effect);
                     final AudioFormatType aft = soundFormat.get(effect);
-                    final SourceDataLine sdl = getLine(aft);
-
-                    if (sdl != null) {
-                        final Object cancelSync = new Object();
-                        final AtomicBoolean done = new AtomicBoolean();
-
-                        final Future<?> f = exec.submit(new Runnable() {
-                            @Override
-                            public void run() {
-                                try {
-                                    String n = Thread.currentThread().getName();
-                                    Thread.currentThread().setName(n + "-" + effect);
-                                    try {
-                                        AudioThread.setVolume(sdl, vol);
-                                        sdl.start();
-                                        do {
-                                            sdl.write(data, 0, data.length);
-                                        } while (loop && !done.get() && !Thread.currentThread().isInterrupted());
-                                        sdl.drain();
-                                        sdl.stop();
-                                    } catch (Throwable t) {
-                                        Exceptions.add(t);
-                                    } finally {
-                                        Thread.currentThread().setName(n);
-
-                                        synchronized (cancelSync) {
-                                            putBackLine(aft, sdl);
-                                            done.set(true);
-                                        }
-                                        effectSemaphore.release();
-                                    }
-                                } finally {
-                                    edt(action);
-                                }
-                            }
-                        });
-                        return new Action0() {
-                            @Override
-                            public void invoke() {
-                                synchronized (cancelSync) {
-                                    if (!done.get()) {
-                                        done.set(true);
-                                        sdl.flush();
-                                        f.cancel(true);
-                                    }
-                                }
-                            }
-                        };
+                    if (data == null || aft == null) {
+                        effectSemaphore.release();
+                        edt(action);
+                        return null;
                     }
+
+                    final Object cancelSync = new Object();
+                    final AtomicBoolean done = new AtomicBoolean();
+                    final AtomicReference<SourceDataLine> sdlRef = new AtomicReference<>();
+
+                    final Future<?> f = exec.submit(new Runnable() {
+                        @Override
+                        public void run() {
+                            try {
+                                String n = Thread.currentThread().getName();
+                                Thread.currentThread().setName(n + "-" + effect);
+                                SourceDataLine sdl = null;
+                                try {
+                                    if (done.get()) {
+                                        return;
+                                    }
+                                    sdl = getLine(aft);
+                                    if (sdl == null) {
+                                        return;
+                                    }
+                                    synchronized (cancelSync) {
+                                        if (done.get()) {
+                                            putBackLine(aft, sdl);
+                                            sdl = null;
+                                            return;
+                                        }
+                                        sdlRef.set(sdl);
+                                    }
+                                    AudioThread.setVolume(sdl, vol);
+                                    sdl.start();
+                                    do {
+                                        sdl.write(data, 0, data.length);
+                                    } while (loop && !done.get() && !Thread.currentThread().isInterrupted());
+                                    sdl.drain();
+                                    sdl.stop();
+                                } catch (Throwable t) {
+                                    Exceptions.add(t);
+                                } finally {
+                                    Thread.currentThread().setName(n);
+                                    synchronized (cancelSync) {
+                                        SourceDataLine toReturn = sdlRef.getAndSet(null);
+                                        if (toReturn != null) {
+                                            putBackLine(aft, toReturn);
+                                        }
+                                        done.set(true);
+                                    }
+                                    effectSemaphore.release();
+                                }
+                            } finally {
+                                edt(action);
+                            }
+                        }
+                    });
+                    return new Action0() {
+                        @Override
+                        public void invoke() {
+                            synchronized (cancelSync) {
+                                if (!done.get()) {
+                                    done.set(true);
+                                    SourceDataLine sdl = sdlRef.get();
+                                    if (sdl != null) {
+                                        try {
+                                            sdl.flush();
+                                        } catch (Throwable t) {
+                                            // ignored
+                                        }
+                                    }
+                                    f.cancel(true);
+                                }
+                            }
+                        }
+                    };
                 } catch (RejectedExecutionException ex) {
                     effectSemaphore.release();
                 }


### PR DESCRIPTION
## Summary

Space combat stuttered once weapons started firing because every effect went through `Sounds.playSound()`, and that path opened a new `SourceDataLine` on the **caller** (simulation) thread, then closed it when playback finished. The class already had a per-format line pool (`soundPool`), but it was unused: `getLine()` always created a line and `putBackLine()` always closed it.

Under fire, many effects are requested per simulation step. Repeated line open/close on that thread added large stalls to the spacewar tick, so the battle screen hitch as soon as shots and impacts played. The same cost applies anywhere effects are used; combat just hits it hardest.

This change keeps the public API the same and only fixes `Sounds`:
- Reuse idle lines from the pool instead of open/close per effect
- Acquire/open the line on the audio worker thread, not the caller
- Return lines to the pool in a stopped, flushed state so reuse is safe
Also improves permit handling when a line cannot be obtained (the old path could leak a semaphore permit).

Note: AI assistance was utilized during the refactoring process to fix this issue.

Fixes https://github.com/akarnokd/open-ig/issues/1221