### PR TITLE
Hoist constant paint Colors/Strokes to static fields

### DIFF
--- a/src/hu/openig/render/RenderTools.java
+++ b/src/hu/openig/render/RenderTools.java
@@ -36,6 +36,15 @@ public final class RenderTools {
     /** Utility class. */
     private RenderTools() {
     }
+    /** Prebuilt A–Y labels for starmap / minimap grids. */
+    private static final String[] GRID_LABELS;
+    static {
+        GRID_LABELS = new String[25];
+        int i = 0;
+        for (char c = 'A'; c < 'Z'; c++) {
+            GRID_LABELS[i++] = String.valueOf(c);
+        }
+    }
     /** The top status bar height constant. */
     public static final int STATUS_BAR_TOP = 20;
     /** The bottom status bar height constant. */
@@ -201,8 +210,8 @@ public final class RenderTools {
         int i = 0;
         y0 = dy - 6;
         x0 = 2;
-        for (char c = 'A'; c < 'Z'; c++) {
-            text.paintTo(g2, (int)(rect.x + x0), (int)(rect.y + y0), 5, TextRenderer.GRAY, String.valueOf(c));
+        for (String label : GRID_LABELS) {
+            text.paintTo(g2, (int)(rect.x + x0), (int)(rect.y + y0), 5, TextRenderer.GRAY, label);
             x0 += dx;
             i++;
             if (i % 5 == 0) {

--- a/src/hu/openig/render/TextRenderer.java
+++ b/src/hu/openig/render/TextRenderer.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -32,6 +33,10 @@ import javax.xml.stream.XMLStreamException;
  * @author akarnokd
  */
 public class TextRenderer {
+    /** Split text into paragraphs. */
+    private static final Pattern PARAGRAPH_SPLIT = Pattern.compile("\n");
+    /** Split a paragraph into words. */
+    private static final Pattern WORD_SPLIT = Pattern.compile("\\s+");
     /**
      * Record to store a particularly sized character series's width and height.
      * @author akarnokd
@@ -493,13 +498,13 @@ public class TextRenderer {
     public int wrapText(String text, int width, int size, List<String> linesOut) {
         linesOut.clear();
         int maxWidth = 0;
-        String[] par = text.split("\n");
+        String[] par = PARAGRAPH_SPLIT.split(text);
         for (String s : par) {
             if (s.trim().isEmpty()) {
                 linesOut.add("");
                 continue;
             }
-            String[] words = s.split("\\s+");
+            String[] words = WORD_SPLIT.split(s);
             StringBuilder line = new StringBuilder();
             StringBuilder lineTest = new StringBuilder();
             for (int i = 0; i < words.length; i++) {

--- a/src/hu/openig/screen/items/PlanetScreen.java
+++ b/src/hu/openig/screen/items/PlanetScreen.java
@@ -37,6 +37,16 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
     /** Indicate if a component is drag sensitive. */
     @Retention(RetentionPolicy.RUNTIME)
     @interface DragSensitive { }
+    /** Friendly unit HP bar color. */
+    static final Color FRIEND_HP = new Color(0x458AAA);
+    /** Enemy unit HP bar color. */
+    static final Color ENEMY_HP = new Color(0xAE6951);
+    /** Semi-transparent background for pavement price labels. */
+    static final AlphaComposite TEXT_BG_50 = AlphaComposite.SrcOver.derive(0.5f);
+    /** Semi-transparent background for building name labels. */
+    static final AlphaComposite TEXT_BG_80 = AlphaComposite.SrcOver.derive(0.8f);
+    /** Semi-transparent background for info panel. */
+    static final AlphaComposite PANEL_BG_85 = AlphaComposite.SrcOver.derive(0.85f);
     /**
 
      * The selected rectangular region. The X coordinate is the smallest, the Y coordinate is the largest
@@ -1426,8 +1436,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
 
                             if (config.buildingTextBackgrounds) {
                                 Composite compositeSave = g2.getComposite();
-                                AlphaComposite a1 = AlphaComposite.SrcOver.derive(0.5f);
-                                g2.setComposite(a1);
+                                g2.setComposite(TEXT_BG_50);
                                 g2.setColor(Color.BLACK);
                                 g2.fillRect(px0 - 2, py0 - 2, priceWidth + 4, 14);
                                 g2.setComposite(compositeSave);
@@ -1642,7 +1651,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
 
                 if (config.buildingTextBackgrounds) {
                     compositeSave = g2.getComposite();
-                    a1 = AlphaComposite.SrcOver.derive(0.8f);
+                    a1 = TEXT_BG_80;
                     g2.setComposite(a1);
                     g2.setColor(Color.BLACK);
                     g2.fillRect(nx - 2, ny - 2, nameLen + 4, nameSize + 5);
@@ -3171,7 +3180,7 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
         @Override
         public void draw(Graphics2D g2) {
             Composite c = g2.getComposite();
-            g2.setComposite(AlphaComposite.SrcOver.derive(0.85f));
+            g2.setComposite(PANEL_BG_85);
             g2.setColor(Color.BLACK);
             g2.fillRoundRect(0, 0, width, height, 10, 10);
             g2.setComposite(c);
@@ -4415,9 +4424,9 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
             g2.setColor(Color.BLACK);
             g2.fillRect(p.x + 4, p.y + 3, u.model.width - 7, 5);
             if (u.owner == player()) {
-                g2.setColor(new Color(0x458AAA));
+                g2.setColor(FRIEND_HP);
             } else {
-                g2.setColor(new Color(0xAE6951));
+                g2.setColor(ENEMY_HP);
             }
             g2.fillRect(p.x + 5, p.y + 4, (int)(u.hp * (u.model.width - 9) / u.model.hp), 3);
 

--- a/src/hu/openig/screen/items/SpacewarScreen.java
+++ b/src/hu/openig/screen/items/SpacewarScreen.java
@@ -88,7 +88,6 @@ import java.awt.Paint;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Shape;
-import java.awt.Stroke;
 import java.awt.TexturePaint;
 import java.awt.event.KeyEvent;
 import java.awt.geom.AffineTransform;
@@ -117,6 +116,17 @@ import java.util.Set;
  * @author akarnokd, 2010.01.06.
  */
 public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
+    /** Grid overlay color. */
+    static final Color GRID_COLOR = new Color(0, 128, 0, 255);
+    /** Dashed stroke pattern for the grid. */
+    static final float[] GRID_DASH = { 3f };
+    /** Dashed stroke for the grid. */
+    static final BasicStroke GRID_STROKE = new BasicStroke(1, BasicStroke.CAP_BUTT,
+            BasicStroke.JOIN_BEVEL, 0, GRID_DASH, 0);
+    /** Selection-box fill color. */
+    static final Color SELECTION_BOX = new Color(255, 255, 255, 128);
+    /** Shield bar color. */
+    static final Color SHIELD_BAR = new Color(0xFFFFCC00);
     /** The movement handler object responsible for handling space war unit movements. */
     WarMovementHandler movementHandler;
     /** Annotation to show a component on a specified panel mode. */
@@ -1939,10 +1949,8 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
 
         if (viewGrid.selected) {
             Graphics2D gr = (Graphics2D) g2.create();
-            gr.setColor(new Color(0, 128, 0, 255));
-            Stroke dashed = new BasicStroke(1, BasicStroke.CAP_BUTT, BasicStroke.JOIN_BEVEL,
-                    0, new float[]{3}, 0);
-            gr.setStroke(dashed);
+            gr.setColor(GRID_COLOR);
+            gr.setStroke(GRID_STROKE);
             for (int i = 0; i <= gridSizeX; i++) {
                 gr.drawLine(i * GRID_CELL_SIZE + gridOffsetX, 0, i * GRID_CELL_SIZE + gridOffsetX, space.height);
             }
@@ -2008,7 +2016,7 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
             int sy0 = Math.min(selectionStart.y, selectionEnd.y);
             int sx1 = Math.max(selectionStart.x, selectionEnd.x);
             int sy1 = Math.max(selectionStart.y, selectionEnd.y);
-            g2.setColor(new Color(255, 255, 255, 128));
+            g2.setColor(SELECTION_BOX);
             g2.fillRect(sx0, sy0, sx1 - sx0 + 1, sy1 - sy0 + 1);
         }
 
@@ -2143,7 +2151,7 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
                 g2.setColor(Color.RED);
                 g2.drawRect((int)e.x - w2 + 3, y, dw, 4);
                 if (e.shieldMax > 0) {
-                    g2.setColor(new Color(0xFFFFCC00));
+                    g2.setColor(SHIELD_BAR);
                     g2.fillRect((int)e.x - w2 + 3, y, (int)(e.shield * dw / e.shieldMax), 4);
                 }
             }

--- a/src/hu/openig/screen/items/StarmapScreen.java
+++ b/src/hu/openig/screen/items/StarmapScreen.java
@@ -71,6 +71,16 @@ import java.util.Set;
  * @author akarnokd, 2010.01.11.
  */
 public class StarmapScreen extends ScreenBase {
+    /** Fleet path stroke for attack/move arrows. */
+    static final BasicStroke FLEET_PATH_STROKE = new BasicStroke(1.5f);
+    /** Attack-mode fleet path color. */
+    static final Color FLEET_PATH_ATTACK = new Color(255, 0, 0, 128);
+    /** Move-mode fleet path color. */
+    static final Color FLEET_PATH_MOVE = new Color(124, 124, 180, 128);
+    /** Exploration fog fill color. */
+    static final Color EXPLORATION_FOG = new Color(0x80000000, true);
+    /** Radar union area fill color. */
+    static final Color RADAR_FILL = new Color(128, 0, 0, 32);
     /** The horizontal/vertical scrollbar painter. */
     public class ScrollBarPainter {
         /** Horizontal scroll rectangle. */
@@ -1304,10 +1314,10 @@ public class StarmapScreen extends ScreenBase {
             for (Fleet f : fleets) {
                 if (f.owner == player()) {
                     Stroke defaultStroke = g2.getStroke();
-                    g2.setStroke(new BasicStroke(1.5f));
+                    g2.setStroke(FLEET_PATH_STROKE);
                     if (f.mode == FleetMode.ATTACK) {
                         if (f.targetFleet != null) {
-                            g2.setColor(new Color(255, 0, 0, 128));
+                            g2.setColor(FLEET_PATH_ATTACK);
                             drawArrow(
                                     g2,
                                     (int)(starmapRect.x + f.x * zoom),
@@ -1316,7 +1326,7 @@ public class StarmapScreen extends ScreenBase {
                                     (int)(starmapRect.y + f.targetFleet.y * zoom));
                         } else
                         if (f.targetPlanet() != null) {
-                            g2.setColor(new Color(255, 0, 0, 128));
+                            g2.setColor(FLEET_PATH_ATTACK);
                             drawArrow(
                                     g2,
                                     (int)(starmapRect.x + f.x * zoom),
@@ -1328,7 +1338,7 @@ public class StarmapScreen extends ScreenBase {
                         double lastx = f.x;
                         double lasty = f.y;
                         if (f.targetFleet != null) {
-                            g2.setColor(new Color(124, 124, 180, 128));
+                            g2.setColor(FLEET_PATH_MOVE);
                             drawArrow(
                                     g2,
                                     (int)(starmapRect.x + f.x * zoom),
@@ -1337,7 +1347,7 @@ public class StarmapScreen extends ScreenBase {
                                     (int)(starmapRect.y + f.targetFleet.y * zoom));
                         } else
                         if (f.targetPlanet() != null) {
-                            g2.setColor(new Color(124, 124, 180, 128));
+                            g2.setColor(FLEET_PATH_MOVE);
                             drawArrow(
                                     g2,
                                     (int)(starmapRect.x + f.x * zoom),
@@ -1347,7 +1357,7 @@ public class StarmapScreen extends ScreenBase {
                         } else
 
                         if (f.waypoints.size() > 0) {
-                            g2.setColor(new Color(124, 124, 180, 128));
+                            g2.setColor(FLEET_PATH_MOVE);
                             int i = 0;
                             for (Point2D.Double pt : f.waypoints) {
                                 if (i++ == f.waypoints.size() - 1) {
@@ -1645,7 +1655,7 @@ public class StarmapScreen extends ScreenBase {
             Area a = new Area(new Rectangle(0, 0, world().galaxyModel.map.getWidth(), world().galaxyModel.map.getHeight()));
             a.subtract(new Area(player().explorationOuterLimit));
 
-            g2.setColor(new Color(0x80000000, true));
+            g2.setColor(EXPLORATION_FOG);
 
             drawShape(g2, a, true);
 
@@ -1653,7 +1663,7 @@ public class StarmapScreen extends ScreenBase {
             drawRect(g2, player().explorationOuterLimit, false);
         } else
         if (player().explorationInnerLimit != null) {
-            g2.setColor(new Color(0x80000000, true));
+            g2.setColor(EXPLORATION_FOG);
             drawRect(g2, player().explorationInnerLimit, true);
         }
     }
@@ -2984,7 +2994,7 @@ public class StarmapScreen extends ScreenBase {
         }
         g2.translate(starmapRect.x, starmapRect.y);
         if (radarCache.radarArea != null) {
-            g2.setColor(new Color(128, 0, 0, 32));
+            g2.setColor(RADAR_FILL);
             g2.fill(radarCache.radarArea);
         }
         for (Point p : radarCache.dots) {

--- a/src/hu/openig/screen/panels/ObjectivesView.java
+++ b/src/hu/openig/screen/panels/ObjectivesView.java
@@ -26,6 +26,14 @@ import java.util.List;
  * @author akarnokd, Jan 12, 2012
  */
 public class ObjectivesView extends UIComponent {
+    /** Panel background fill. */
+    static final Color BACKGROUND = new Color(0xC0000000, true);
+    /** Border / separator line color. */
+    static final Color BORDER = new Color(0xFFC0C0C0);
+    /** Objective checkbox outline. */
+    static final Color CHECKBOX = new Color(0xFFB0B0B0);
+    /** Progress bar color. */
+    static final Color PROGRESS = new Color(0xFFFFCC00);
     /** The common resources. */
     final CommonResources commons;
     /** For the statusbar's location info. */
@@ -51,13 +59,11 @@ public class ObjectivesView extends UIComponent {
 
         g2.translate(tx, ty);
         try {
-            int background = 0xC0000000;
-
             List<Objective> objs = commons.world().scripting.currentObjectives();
 
             if (objs.size() == 0) {
                 int w = commons.text().getTextWidth(14, commons.get("no_objectives"));
-                g2.setColor(new Color(background, true));
+                g2.setColor(BACKGROUND);
 
                 String hideS = commons.get("hide_objectives");
                 int hideW = commons.text().getTextWidth(7, hideS);
@@ -67,7 +73,7 @@ public class ObjectivesView extends UIComponent {
                 g2.fillRect(0, 0, w + 10, 33);
                 commons.text().paintTo(g2, 5, 3, 14, TextRenderer.GRAY, commons.get("no_objectives"));
 
-                g2.setColor(new Color(0xFFC0C0C0));
+                g2.setColor(BORDER);
                 g2.drawLine(0, 20, Math.min(hideW, w), 20);
                 commons.text().paintTo(g2, 2, 22, 7, 0xFFFFFF00, hideS);
 
@@ -91,10 +97,10 @@ public class ObjectivesView extends UIComponent {
 
             w = Math.min(Math.max(hideW, w), limit);
 
-            g2.setColor(new Color(background, true));
+            g2.setColor(BACKGROUND);
 
             g2.fillRect(0, 0, w + 4, h + 13);
-            g2.setColor(new Color(0xFFC0C0C0));
+            g2.setColor(BORDER);
             g2.drawRect(0, 0, w + 4, h + 13);
 
             int y = 3;
@@ -102,7 +108,7 @@ public class ObjectivesView extends UIComponent {
                 y += drawObjective(g2, o, 2, y, w);
             }
 
-            g2.setColor(new Color(0xFFC0C0C0));
+            g2.setColor(BORDER);
             g2.drawLine(0, y + 2, Math.min(hideW, w), y + 2);
             commons.text().paintTo(g2, 2, y + 4, 7, 0xFFFFFF00, hideS);
 
@@ -123,7 +129,7 @@ public class ObjectivesView extends UIComponent {
      */
     int drawObjective(Graphics2D g2, Objective o, int x, int y, int w) {
 
-        g2.setColor(new Color(0xFFB0B0B0));
+        g2.setColor(CHECKBOX);
         g2.drawRect(x + 3, y + 3, 14, 14);
         g2.drawRect(x + 4, y + 4, 12, 12);
 
@@ -156,7 +162,7 @@ public class ObjectivesView extends UIComponent {
                 int rw = w - dx;
                 int rwf = (int)(rw * pv);
 
-                g2.setColor(new Color(0xFFFFCC00));
+                g2.setColor(PROGRESS);
                 g2.drawRect(x + dx, y + dy, rw, 7);
                 g2.fillRect(x + dx, y + dy, rwf, 7);
             }

--- a/src/hu/openig/screen/panels/WeatherOverlay.java
+++ b/src/hu/openig/screen/panels/WeatherOverlay.java
@@ -10,7 +10,6 @@ package hu.openig.screen.panels;
 
 import hu.openig.model.WeatherType;
 
-import java.awt.BasicStroke;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
@@ -34,6 +33,8 @@ public class WeatherOverlay {
     public static final double RAIN_VELOCITY = 30;
     /** Snow mode velocity. */
     public static final double SNOW_VELOCITY = 4;
+    /** Steps in the precomputed rain/snow color palettes. */
+    private static final int COLOR_PALETTE_SIZE = 64;
     /** The individual drops. */
     private final List<WeatherDrop> drops = new ArrayList<>(MAX_DROPS);
     /** Current horizontal wind speed. */
@@ -46,6 +47,23 @@ public class WeatherOverlay {
     public static final Color SNOW_COLOR = new Color(255, 255, 255);
     /** The base rain color. */
     public static final Color RAIN_COLOR = new Color(200, 200, 255);
+    /** Precomputed rain colors by brightness step. */
+    private static final Color[] RAIN_COLORS = new Color[COLOR_PALETTE_SIZE];
+    /** Precomputed snow colors by brightness step. */
+    private static final Color[] SNOW_COLORS = new Color[COLOR_PALETTE_SIZE];
+    static {
+        for (int i = 0; i < COLOR_PALETTE_SIZE; i++) {
+            double a = i / (double)(COLOR_PALETTE_SIZE - 1);
+            RAIN_COLORS[i] = new Color(
+                    (int)(RAIN_COLOR.getRed() * a),
+                    (int)(RAIN_COLOR.getGreen() * a),
+                    (int)(RAIN_COLOR.getBlue() * a));
+            SNOW_COLORS[i] = new Color(
+                    (int)(SNOW_COLOR.getRed() * a),
+                    (int)(SNOW_COLOR.getGreen() * a),
+                    (int)(SNOW_COLOR.getBlue() * a));
+        }
+    }
     /** The rendering bounds. */
     public Dimension bounds;
     /** The light level. */
@@ -121,16 +139,8 @@ public class WeatherOverlay {
          */
         private void updateColor() {
             double a = Math.max(0, Math.min(1, alpha + random.nextDouble() * 0.2 - 0.1));
-
-            color = type == WeatherType.RAIN
-//                    ? RAIN_COLOR
-//                    : SNOW_COLOR;
-//                    ? new Color(RAIN_COLOR.getRed(), RAIN_COLOR.getGreen(), RAIN_COLOR.getBlue(), random.nextInt(156) + 50)
-
-//                    : new Color(SNOW_COLOR.getRed(), SNOW_COLOR.getGreen(), SNOW_COLOR.getBlue(), random.nextInt(226) + 30);
-                    ? new Color((int)(RAIN_COLOR.getRed() * a), (int)(RAIN_COLOR.getGreen() * a), (int)(RAIN_COLOR.getBlue() * a))
-
-                    : new Color((int)(SNOW_COLOR.getRed() * a), (int)(SNOW_COLOR.getGreen() * a), (int)(SNOW_COLOR.getBlue() * a));
+            int idx = (int)Math.round(a * (COLOR_PALETTE_SIZE - 1));
+            color = type == WeatherType.RAIN ? RAIN_COLORS[idx] : SNOW_COLORS[idx];
         }
         /**
          * Reposition outbound drop.
@@ -149,7 +159,6 @@ public class WeatherOverlay {
          */
         public void paint(Graphics2D g2) {
             g2.setColor(color);
-            g2.setStroke(new BasicStroke(1, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
             g2.fillRect(shape.x, shape.y, shape.width, shape.height);
         }
     }


### PR DESCRIPTION
## Summary
- Reuse `static final` `Color`, `BasicStroke`, `AlphaComposite`, and precompiled `Pattern` / grid labels instead of allocating them every paint frame.
- Touches objectives panel, colony HP bars, starmap fleet paths / fog / radar fill, spacewar overlays, weather drops, and shared text/grid helpers.

## Tested
- Open colony with objectives panel pinned, layout/colors unchanged
- Starmap with fleets on move/attack paths and radar union on
- Ground war: friendly/enemy HP bars look correct
- Space combat: grid overlay, selection box, shield bars, minimap
- Colony weather (rain/snow) still renders normally