### PR TITLE
Reuse EnumSet for planet problem icon painting

### DIFF
--- a/src/hu/openig/screen/items/PlanetScreen.java
+++ b/src/hu/openig/screen/items/PlanetScreen.java
@@ -203,6 +203,8 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
     boolean showInfo = true;
     /** Show the screen navigation buttons? */
     boolean showSidebarButtons = true;
+    /** Scratch set for merging planet problems + warnings while painting. */
+    final EnumSet<PlanetProblems> planetProblemsScratch = EnumSet.noneOf(PlanetProblems.class);
     /** The set where the vehicles may be placed. */
     final Set<Location> battlePlacements = new HashSet<>();
     /** The ground war units. */
@@ -2042,16 +2044,16 @@ public class PlanetScreen extends ScreenBase implements GroundwarWorld {
          * @param ps the statistics
          */
         void renderProblems(Graphics2D g2, PlanetStatistics ps) {
-            Set<PlanetProblems> combined = new HashSet<>();
-            combined.addAll(ps.problems);
-            combined.addAll(ps.warnings);
+            planetProblemsScratch.clear();
+            planetProblemsScratch.addAll(ps.problems);
+            planetProblemsScratch.addAll(ps.warnings);
 
-            if (combined.size() > 0) {
-                int w = combined.size() * 11 - 1;
+            if (!planetProblemsScratch.isEmpty()) {
+                int w = planetProblemsScratch.size() * 11 - 1;
                 g2.setColor(Color.BLACK);
                 g2.fillRect((width - w) / 2 - 2, 18, w + 4, 15);
                 int i = 0;
-                for (PlanetProblems pp : combined) {
+                for (PlanetProblems pp : planetProblemsScratch) {
                     BufferedImage icon = null;
                     BufferedImage iconDark = null;
                     switch (pp) {

--- a/src/hu/openig/screen/items/StarmapScreen.java
+++ b/src/hu/openig/screen/items/StarmapScreen.java
@@ -60,6 +60,7 @@ import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -81,6 +82,8 @@ public class StarmapScreen extends ScreenBase {
     static final Color EXPLORATION_FOG = new Color(0x80000000, true);
     /** Radar union area fill color. */
     static final Color RADAR_FILL = new Color(128, 0, 0, 32);
+    /** Scratch set for merging planet problems + warnings while painting. */
+    final EnumSet<PlanetProblems> planetProblemsScratch = EnumSet.noneOf(PlanetProblems.class);
     /** The horizontal/vertical scrollbar painter. */
     public class ScrollBarPainter {
         /** Horizontal scroll rectangle. */
@@ -1564,14 +1567,14 @@ public class StarmapScreen extends ScreenBase {
                 g2.drawImage(msi, msix , msiy, null);
             }
 
-            Set<PlanetProblems> combined = new HashSet<>();
-            combined.addAll(ps.problems);
-            combined.addAll(ps.warnings);
+            planetProblemsScratch.clear();
+            planetProblemsScratch.addAll(ps.problems);
+            planetProblemsScratch.addAll(ps.warnings);
 
-            if (combined.size() > 0) {
-                int w = combined.size() * 11 - 1;
+            if (!planetProblemsScratch.isEmpty()) {
+                int w = planetProblemsScratch.size() * 11 - 1;
                 int i = 0;
-                for (PlanetProblems pp : combined) {
+                for (PlanetProblems pp : planetProblemsScratch) {
                     BufferedImage icon = null;
                     BufferedImage iconDark = null;
                     switch (pp) {


### PR DESCRIPTION
## Summary
- Avoid allocating a new `HashSet` per owned planet every starmap/colony paint when merging problem and warning icons.
- Reuse a field `EnumSet<PlanetProblems>` (`clear` + `addAll`) in `StarmapScreen` and `PlanetScreen`.

## Tested
- Starmap: owned planets with housing/food/energy problems or warnings still show the correct icons
- Colony view: problem icon strip at the top still matches previous behavior
- Planets with no problems/warnings show no icon strip