### PR TITLE
Cache player AWT colors for starmap and info minimaps

### DIFF
--- a/src/hu/openig/model/Player.java
+++ b/src/hu/openig/model/Player.java
@@ -12,6 +12,7 @@ import hu.openig.core.Difficulty;
 import hu.openig.core.Pair;
 import hu.openig.utils.Exceptions;
 
+import java.awt.Color;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
@@ -44,6 +45,10 @@ public class Player {
     public String shortName;
     /** The coloring used for this player. */
     public int color;
+    /** Cached AWT color for {@link #color}; rebuilt when the packed RGB changes. */
+    private Color awtColor;
+    /** Packed RGB that {@link #awtColor} was built from. */
+    private int awtColorRgb;
     /** The fleet icon. */
     public BufferedImage fleetIcon;
     /** The picture used in the database screen. */
@@ -170,6 +175,17 @@ public class Player {
         aiDefensiveLimits.put(Difficulty.EASY, 1);
         aiDefensiveLimits.put(Difficulty.NORMAL, 3);
         aiDefensiveLimits.put(Difficulty.HARD, 5);
+    }
+    /**
+     * Returns a reusable AWT {@link Color} for this player's packed {@link #color}.
+     * @return the color
+     */
+    public Color awtColor() {
+        if (awtColor == null || awtColorRgb != color) {
+            awtColorRgb = color;
+            awtColor = new Color(color);
+        }
+        return awtColor;
     }
     /** @return the socual ratio for AI player. Ratios sum up to 1. */
     public double aiSocialRatio() {

--- a/src/hu/openig/screen/items/InfoScreen.java
+++ b/src/hu/openig/screen/items/InfoScreen.java
@@ -88,6 +88,8 @@ import java.util.Set;
  * @author akarnokd, 2010.01.11.
  */
 public class InfoScreen extends ScreenBase {
+    /** Minimap / selection outline gray ({@link TextRenderer#GRAY}). */
+    static final Color MINIMAP_GRAY = new Color(TextRenderer.GRAY);
     /**
 
      * The annotation to indicate which UI elements should by default
@@ -1976,16 +1978,16 @@ public class InfoScreen extends ScreenBase {
                 }
                 int x0 = (p.x * width / commons.starmap().background.getWidth());
                 int y0 = (p.y * height / commons.starmap().background.getHeight());
-                int labelColor = TextRenderer.GRAY;
                 if (p.owner != null && knowledge(p, PlanetKnowledge.OWNER) >= 0) {
-                    labelColor = p.owner.color;
+                    g2.setColor(p.owner.awtColor());
+                } else {
+                    g2.setColor(MINIMAP_GRAY);
                 }
-                g2.setColor(new Color(labelColor));
 //                if (p != planet() || (p == planet() && animationBlink)) {
                     g2.fillRect(x0 - 1, y0 - 1, 3, 3);
 //                }
                 if (p == planet()) {
-                    g2.setColor(new Color(TextRenderer.GRAY));
+                    g2.setColor(MINIMAP_GRAY);
                     g2.drawRect(x0 - 3, y0 - 3, 6, 6);
                 }
             }
@@ -1998,7 +2000,7 @@ public class InfoScreen extends ScreenBase {
                         int y1 = y0 - f.owner.fleetIcon.getHeight() / 2;
                         g2.drawImage(f.owner.fleetIcon, x1, y1, null);
                         if (f == fleet()) {
-                            g2.setColor(new Color(f.owner.color));
+                            g2.setColor(f.owner.awtColor());
                             g2.drawRect(x1 - 2, y1 - 2, f.owner.fleetIcon.getWidth() + 4, f.owner.fleetIcon.getHeight() + 4);
                         }
                     }
@@ -2147,7 +2149,7 @@ public class InfoScreen extends ScreenBase {
                         String t = getText.invoke(p);
                         commons.text().paintTo(g2, x0, y0 + 1, fontSize, c, t);
                         if (p == getCurrent.invoke(null)) {
-                            g2.setColor(new Color(player().color));
+                            g2.setColor(player().awtColor());
                             g2.drawRect(x0 - 2, y0 - 1, columnWidth, rowHeight);
                         }
                     }
@@ -2399,7 +2401,7 @@ public class InfoScreen extends ScreenBase {
                             commons.text().paintTo(g2, x0, y0 + 4, 7, col, n);
                         }
                         if (p == player().currentBuilding) {
-                            g2.setColor(new Color(player().color));
+                            g2.setColor(player().awtColor());
                             g2.drawRect(x0 - 2 + 30, y0, columnWidth - 30, rowHeight);
                         }
                     }

--- a/src/hu/openig/screen/items/StarmapScreen.java
+++ b/src/hu/openig/screen/items/StarmapScreen.java
@@ -82,6 +82,8 @@ public class StarmapScreen extends ScreenBase {
     static final Color EXPLORATION_FOG = new Color(0x80000000, true);
     /** Radar union area fill color. */
     static final Color RADAR_FILL = new Color(128, 0, 0, 32);
+    /** Minimap color for unowned / unknown-owner planets. */
+    static final Color MINIMAP_UNOWNED = new Color(TextRenderer.GRAY);
     /** Scratch set for merging planet problems + warnings while painting. */
     final EnumSet<PlanetProblems> planetProblemsScratch = EnumSet.noneOf(PlanetProblems.class);
     /** The horizontal/vertical scrollbar painter. */
@@ -1491,11 +1493,11 @@ public class StarmapScreen extends ScreenBase {
                 if (p != planet() || minimapPlanetBlink) {
                     int x0 = minimapInnerRect.x + (p.x * minimapInnerRect.width / commons.starmap().background.getWidth());
                     int y0 = minimapInnerRect.y + (p.y * minimapInnerRect.height / commons.starmap().background.getHeight());
-                    int labelColor = TextRenderer.GRAY;
                     if (p.owner != null && knowledge(p, PlanetKnowledge.OWNER) >= 0) {
-                        labelColor = p.owner.color;
+                        g2.setColor(p.owner.awtColor());
+                    } else {
+                        g2.setColor(MINIMAP_UNOWNED);
                     }
-                    g2.setColor(new Color(labelColor));
                     g2.fillRect(x0 - 1, y0 - 1, 3, 3);
                 }
             }

--- a/src/hu/openig/screen/panels/EquipmentMinimap.java
+++ b/src/hu/openig/screen/panels/EquipmentMinimap.java
@@ -67,7 +67,7 @@ public class EquipmentMinimap extends UIComponent {
                 int cx = (int)(p.x * zoom);
                 int cy = (int)(p.y * zoom);
 
-                g2.setColor(new Color(p.owner.color));
+                g2.setColor(p.owner.awtColor());
                 g2.fillRect(cx - 1, cy - 1, 3, 3);
 
                 if (commons.world().player.currentPlanet == p) {


### PR DESCRIPTION
## Summary
- Cache an AWT `Color` on `Player` derived from the existing packed `int color`, so minimap planet/fleet dots stop allocating `new Color(...)` every frame.
- Reuse a static gray for unowned/unknown planets and update starmap, equipment, and info minimap draw paths to use the cached colors.

## Tested
- Starmap minimap: owned planets show correct race colors; unknown/unowned stay gray.
- Leave starmap open and pan/zoom; dots still update without visual glitches.
- Equipment screen minimap: planet dots and selection highlight look unchanged.
- Info screen minimap: planet dots, selected-planet outline, and fleet highlight use correct colors.
- Skirmish with several races: each owner's dots match their label color.