### PR TITLE
Rewrite spacewar selection panel for performance and layout

### DIFF
--- a/src/hu/openig/model/SpacewarStructure.java
+++ b/src/hu/openig/model/SpacewarStructure.java
@@ -370,7 +370,7 @@ public class SpacewarStructure extends SpacewarObject implements WarUnit {
      * @return true if within longest beam range
      */
     public boolean isInRange(SpacewarObject target) {
-        return distanceTo(target) <= maximumRange;
+        return maximumRange > 0 && maximumRange >= distanceTo(target);
     }
     /**
      * Returns a list of those BEAM weapon ports, which have the target structure in range.

--- a/src/hu/openig/model/SpacewarStructure.java
+++ b/src/hu/openig/model/SpacewarStructure.java
@@ -364,20 +364,35 @@ public class SpacewarStructure extends SpacewarObject implements WarUnit {
         return r;
     }
     /**
+     * Returns true if at least one BEAM weapon can reach the target.
+     * Uses {@link #maximumRange} — no port iteration / list allocation.
+     * @param target the target structure
+     * @return true if within longest beam range
+     */
+    public boolean isInRange(SpacewarObject target) {
+        return distanceTo(target) <= maximumRange;
+    }
+    /**
      * Returns a list of those BEAM weapon ports, which have the target structure in range.
      * @param target the target structure
      * @return the list of weapon ports
      */
     public List<SpacewarWeaponPort> inRange(SpacewarObject target) {
         List<SpacewarWeaponPort> result = new ArrayList<>();
-        double d = Math.hypot(x - target.x, y - target.y);
+        double d = distanceTo(target);
         for (SpacewarWeaponPort p : ports) {
             if (p.projectile.range >= d && p.projectile.mode == Mode.BEAM) {
                 result.add(p);
             }
         }
-
         return result;
+    }
+    /**
+     * @param target the other object
+     * @return Euclidean distance to the target
+     */
+    double distanceTo(SpacewarObject target) {
+        return Math.hypot(x - target.x, y - target.y);
     }
     /**
      * Apply damage to this structure, considering the shield level and

--- a/src/hu/openig/screen/items/SpacewarScreen.java
+++ b/src/hu/openig/screen/items/SpacewarScreen.java
@@ -9,6 +9,7 @@
 package hu.openig.screen.items;
 
 import hu.openig.core.Action0;
+import hu.openig.core.Action1;
 import hu.openig.core.Difficulty;
 import hu.openig.core.Func1;
 import hu.openig.core.Location;
@@ -63,9 +64,9 @@ import hu.openig.model.TraitKind;
 import hu.openig.model.WarUnit;
 import hu.openig.render.RenderTools;
 import hu.openig.render.TextRenderer;
-import hu.openig.render.TextRenderer.TextSegment;
 import hu.openig.screen.ScreenBase;
 import hu.openig.screen.panels.EquipmentConfigure;
+import hu.openig.screen.panels.SpacewarSelectionPanel;
 import hu.openig.screen.panels.ThreePhaseButton;
 import hu.openig.screen.panels.TwoPhaseButton;
 import hu.openig.ui.HorizontalAlignment;
@@ -315,7 +316,7 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
     /** Fleet control button. */
     ThreePhaseButton rocketButton;
     /** The middle selection panel. */
-    SelectionPanel selectionPanel;
+    SpacewarSelectionPanel selectionPanel;
     /** The simulation delay on normal speed. */
     static final int SIMULATION_DELAY = 100;
     /** Keep the last info images. */
@@ -419,7 +420,39 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
         leftPanel = new StatusPanel(true);
         rightPanel = new StatusPanel(false);
 
-        selectionPanel = new SelectionPanel();
+        selectionPanel = new SpacewarSelectionPanel(commons);
+        selectionPanel.structures = structures;
+        selectionPanel.groups = groups;
+        selectionPanel.onSelectAll = new Action0() {
+            @Override
+            public void invoke() {
+                doSelectAll();
+            }
+        };
+        selectionPanel.onDeselectAll = new Action0() {
+            @Override
+            public void invoke() {
+                deselectAll();
+            }
+        };
+        selectionPanel.onRecallGroup = new Action1<Integer>() {
+            @Override
+            public void invoke(Integer value) {
+                recallGroup(value);
+            }
+        };
+        selectionPanel.onRemoveGroup = new Action1<Integer>() {
+            @Override
+            public void invoke(Integer value) {
+                removeGroup(value);
+            }
+        };
+        selectionPanel.onSelectionModified = new Action0() {
+            @Override
+            public void invoke() {
+                displaySelectedShipInfo();
+            }
+        };
 
         addThis();
     }
@@ -3676,7 +3709,7 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
         List<SpacewarStructure> result = new ArrayList<>();
         for (SpacewarStructure s : structures) {
             if (!areAllies(s.owner, ship.owner) && !s.isDestroyed()) {
-                if (ship.inRange(s).size() > 0) {
+                if (ship.isInRange(s)) {
                     result.add(s);
                 }
             }
@@ -4066,7 +4099,7 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
                 }
                 if (ship.attackUnit != null && !ship.flee) {
                     if (ship.attackUnit.isDestroyed()
-                            || (ship.guard && ship.inRange(ship.attackUnit).isEmpty())
+                            || (ship.guard && !ship.isInRange(ship.attackUnit))
                             || (!ship.attackUnit.isRocket()
                                     && !ship.attackUnit.intersects(0, 0, space.width, space.height))) {
                         guard(ship);
@@ -5134,480 +5167,6 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
      */
     public void viewGridSelected(boolean selected) {
         viewGrid.selected = selected;
-    }
-    /**
-     * The selection cell.
-     * @author akarnokd, 2012.01.11.
-     */
-    class SelectionCell {
-        /** The object's name. */
-        String name;
-        /** The object's owner. */
-        String owner;
-        /** The objects parent. */
-        String parent;
-        /** The color of the owner. */
-        int color;
-        /** The image. */
-        BufferedImage image;
-        /** The shield ratio. */
-        double shieldRatio;
-        /** The HP ratio. */
-        double hpRatio;
-        /** The firepower. */
-        double firepower;
-        /** The damage per second. */
-        double dps;
-        /** The rocket count. */
-        int rockets;
-        /** The bomb count. */
-        int bombs;
-        /** Count. */
-        int count;
-        /** The maximum image size. */
-        static final int MAX_IMAGE = 50;
-        /** Hitpoints. */
-        int hp;
-        /** Shield points. */
-        int sp;
-        /** The computed location of the cell. */
-        Rectangle bounds;
-        /** The original structure. */
-        final SpacewarStructure structure;
-        /**
-         * Construct a cell.
-         * @param s the original structure
-         */
-        SelectionCell(SpacewarStructure s) {
-            this.structure = s;
-
-            image = s.angles[0];
-            if (s.item != null) {
-                name = s.item.type.name;
-            } else
-            if (s.building != null) {
-                name = s.building.type.name;
-            }
-            owner = s.owner.name;
-            color = s.owner.color;
-            if (s.fleet != null) {
-                parent = s.fleet.name();
-            } else
-            if (s.planet != null) {
-                parent = s.planet.name();
-            }
-
-            hp = (int)s.hp;
-
-            hpRatio = 1.0 * s.hp / s.hpMax;
-            if (s.shieldMax > 0) {
-                shieldRatio = 1.0 * s.shield / s.shieldMax;
-                sp = (int)s.shield;
-
-            } else {
-                shieldRatio = -1;
-                sp = -1;
-            }
-            count = s.count;
-
-            for (SpacewarWeaponPort p : s.ports) {
-                if (p.projectile.mode == Mode.BEAM) {
-                    double dmg = p.damage(s.owner);
-                    firepower += p.count * dmg * count;
-                    dps += p.count * dmg * count * 1000.0 / p.projectile.delay;
-                } else
-                if (p.projectile.mode == Mode.ROCKET || p.projectile.mode == Mode.MULTI_ROCKET) {
-                    rockets += p.count;
-                } else
-                if (p.projectile.mode == Mode.BOMB || p.projectile.mode == Mode.VIRUS) {
-                    bombs += p.count;
-                }
-            }
-            dps = Math.round(dps);
-
-        }
-        /**
-         * Returns the rendering width.
-         * @return the rendering width
-         */
-        int width() {
-            int w = 0;
-            if (count < 2) {
-                w = Math.max(w, commons.text().getTextWidth(7, format("spacewar.selection.name", name)));
-            } else {
-                w = Math.max(w, commons.text().getTextWidth(7, format("spacewar.selection.name_count", name, count)));
-            }
-            w = Math.max(w, commons.text().getTextWidth(7, format("spacewar.selection.owner", owner)));
-            w = Math.max(w, commons.text().getTextWidth(7, format("spacewar.selection.parent", parent)));
-            w = Math.max(w, commons.text().getTextWidth(7, format("spacewar.selection.firepower_dps", (int)firepower, dps)));
-            if (rockets > 0 || bombs > 0) {
-                w = Math.max(w, commons.text().getTextWidth(7, format("spacewar.selection.bombs_rockets", bombs, rockets)));
-            }
-            // defense values
-            int dv = commons.text().getTextWidth(7, get("spacewar.selection.defense_values"));
-            dv += commons.text().getTextWidth(7, Integer.toString(hp));
-            if (sp >= 0) {
-                dv += commons.text().getTextWidth(7, " + ");
-                dv += commons.text().getTextWidth(7, Integer.toString(sp));
-                dv += commons.text().getTextWidth(7, " = ");
-                dv += commons.text().getTextWidth(7, Integer.toString(sp + hp));
-            }
-            w = Math.max(w, dv);
-
-            return w + Math.min(MAX_IMAGE, image.getWidth()) + 15;
-        }
-        /**
-         * The total text height.
-         * @return the total text height
-         */
-        int textHeight() {
-            int rows = 5;
-            if (rockets > 0 || bombs > 0) {
-                rows++;
-            }
-            return 7 * rows + (rows - 1) * 2;
-        }
-        /**
-         * Returns the rendering height.
-         * @return the rendering height
-         */
-        int height() {
-            int h = MAX_IMAGE + 10;
-            h = Math.max(h, textHeight() + 2);
-            return h;
-        }
-        /**
-         * Draws the cell.
-         * @param g2 the graphics context
-         * @param x0 the origin X
-         * @param y0 the origin Y
-         */
-        public void draw(Graphics2D g2, int x0, int y0) {
-            g2.translate(x0, y0);
-
-            g2.setColor(Color.LIGHT_GRAY);
-
-            int h = height();
-//            int w = width();
-
-//            g2.drawRect(0, 0, w, h);
-            int dy = (h - 10 - Math.min(50, image.getHeight())) / 2;
-
-            g2.setColor(Color.GREEN);
-            int iw = Math.min(image.getWidth(), MAX_IMAGE);
-            int iw2 = (int)(iw * hpRatio);
-            g2.drawRect(0, dy + 0, iw, 4);
-            g2.fillRect(0, dy + 0, iw2, 4);
-
-            if (shieldRatio >= 0) {
-                g2.setColor(Color.ORANGE);
-                iw2 = (int)(iw * shieldRatio);
-                g2.drawRect(0, dy + 6, iw, 4);
-                g2.fillRect(0, dy + 6, iw2, 4);
-            }
-
-            if (image.getWidth() > MAX_IMAGE || image.getHeight() > MAX_IMAGE) {
-                double scalex = 1.0 * MAX_IMAGE / image.getWidth();
-                double scaley = 1.0 * MAX_IMAGE / image.getHeight();
-                double scale = Math.min(scalex, scaley);
-
-                int imw = (int)(image.getWidth() * scale);
-                int imh = (int)(image.getHeight() * scale);
-
-                int dx = (MAX_IMAGE - imw) / 2;
-                dy = (MAX_IMAGE - imh) / 2 + 10;
-
-                g2.drawImage(image, dx, dy, imw, imh, null);
-            } else {
-                g2.drawImage(image, 0, dy + 10, null);
-            }
-
-            int dx = Math.min(MAX_IMAGE, image.getWidth()) + 4;
-
-            dy = (h - textHeight()) / 2;
-
-            if (count > 1) {
-                commons.text().paintTo(g2, dx, dy, 7, color, format("spacewar.selection.name_count", name, count));
-            } else {
-                commons.text().paintTo(g2, dx, dy, 7, color, format("spacewar.selection.name", name));
-            }
-            commons.text().paintTo(g2, dx, dy + 9, 7, color, format("spacewar.selection.owner", owner));
-            commons.text().paintTo(g2, dx, dy + 18, 7, color, format("spacewar.selection.parent", parent));
-            commons.text().paintTo(g2, dx, dy + 27, 7, color, format("spacewar.selection.firepower_dps", (int)firepower, (int)dps));
-            int y2 = dy + 36;
-            if (rockets > 0 || bombs > 0) {
-                commons.text().paintTo(g2, dx, y2, 7, color, format("spacewar.selection.bombs_rockets", bombs, rockets));
-                y2 += 9;
-            }
-
-            List<TextSegment> tss = new ArrayList<>();
-            tss.add(new TextSegment(get("spacewar.selection.defense_values"), color));
-            tss.add(new TextSegment(Integer.toString(hp), Color.GREEN.getRGB()));
-            if (sp >= 0) {
-                tss.add(new TextSegment(" + ", color));
-                tss.add(new TextSegment(Integer.toString(sp), Color.ORANGE.getRGB()));
-                tss.add(new TextSegment(" = ", color));
-                tss.add(new TextSegment(Integer.toString(hp + sp), TextRenderer.YELLOW));
-            }
-            commons.text().paintTo(g2, dx, y2, 7, tss);
-
-            g2.translate(-x0, -y0);
-        }
-    }
-    /**
-     * The panel showing information about the current selection.
-
-     * @author akarnokd, 2012.01.11.
-     */
-    class SelectionPanel extends UIContainer {
-        /** The current scroll offset. */
-        int offset = 0;
-        /** The row height. */
-        static final int ROW_HEIGHT = 30;
-        /** The last selection. */
-        List<SpacewarStructure> lastSelection = new ArrayList<>();
-        /** The group buttons. */
-        final List<UIImageButton> groupButtons = new ArrayList<>();
-        /** The cells currently displayable. */
-        final List<SelectionCell> cells = new ArrayList<>();
-        /** Constructs the selection panel buttons. */
-        SelectionPanel() {
-            int x = 5;
-            for (int i = -1; i < 10; i++) {
-                final int j = i;
-
-                UIImageButton ib = new UIImageButton(commons.common().shield) {
-                    @Override
-                    public void draw(Graphics2D g2) {
-                        super.draw(g2);
-                        String s = Integer.toString(j);
-                        if (j < 0) {
-                            s = "*";
-                        }
-                        commons.text().paintTo(g2, 7, 3, 10, TextRenderer.WHITE, s);
-                    }
-                    @Override
-                    public boolean mouse(UIMouse e) {
-                        if (e.has(Button.RIGHT) && e.has(Type.DOWN)) {
-                            if (j >= 0) {
-                                removeGroup(j);
-                            } else {
-                                deselectAll();
-                            }
-                            return true;
-                        }
-                        return super.mouse(e);
-                    }
-                };
-                ib.onClick = new Action0() {
-                    @Override
-                    public void invoke() {
-                        if (j >= 0) {
-                            recallGroup(j);
-                        } else {
-                            doSelectAll();
-                        }
-                    }
-                };
-
-                groupButtons.add(ib);
-                add(ib);
-                ib.x = x;
-
-                x += 25;
-
-                if (i == -1) {
-                    ib.tooltip(get("battle.selectall.tooltip"));
-                } else {
-                    ib.tooltip(format("battle.selectgroup.tooltip", i));
-                }
-            }
-        }
-        @Override
-        public void draw(Graphics2D g2) {
-            Set<Integer> groupSet = U.newSet(groups.values());
-            groupSet.add(-1);
-            for (int i = 0; i < 11; i++) {
-                boolean v0 = groupButtons.get(i).visible();
-                groupButtons.get(i).visible(groupSet.contains(i - 1));
-                if (v0 != groupButtons.get(i).visible()) {
-                    commons.control().moveMouse();
-                }
-            }
-
-            List<SpacewarStructure> sel = getSelection();
-
-            if (sel.size() != lastSelection.size() || !lastSelection.containsAll(sel)) {
-                offset = 0;
-            }
-            lastSelection = sel;
-
-            Shape save = g2.getClip();
-            g2.clipRect(0, 0, width, height);
-
-            g2.setColor(Color.BLACK);
-
-            g2.fillRect(0, 0, width, height);
-
-            offset = Math.max(0, Math.min(offset, sel.size() - 1));
-
-            cells.clear();
-            for (SpacewarStructure s : sel) {
-                SelectionCell c = new SelectionCell(s);
-                cells.add(c);
-            }
-            int x0 = 0;
-            int y0 = 22;
-            int h = 0;
-            int row = 0;
-            for (SelectionCell c : cells) {
-                int cw = c.width();
-                if (x0 > 0 && x0 + cw >= width) {
-                    x0 = 0;
-                    y0 += h;
-                    h = 0;
-                    row++;
-                }
-
-                if (row >= offset) {
-                    c.draw(g2, x0, y0);
-                    int ch = c.height();
-                    c.bounds = new Rectangle(x0, y0, cw, ch);
-                    h = Math.max(h, ch);
-                } else {
-                    c.bounds = null;
-                }
-                x0 += cw;
-            }
-            if (offset > row) {
-                offset = row;
-            }
-
-            super.draw(g2);
-
-            g2.setClip(save);
-        }
-        /** Clear any references. */
-        @Override
-        public void clear() {
-            lastSelection.clear();
-            cells.clear();
-        }
-        @Override
-        public boolean mouse(UIMouse e) {
-            if (e.has(Type.WHEEL)) {
-                if (e.z < 0) {
-                    offset--;
-                } else {
-                    offset++;
-                }
-                return true;
-            }
-            if (e.has(Type.DOWN) && e.has(Button.RIGHT) && e.y >= commons.common().shield[0].getHeight()) {
-                removeFromSelection(e.x, e.y);
-                displaySelectedShipInfo();
-                return true;
-            }
-            if (e.has(Type.DOUBLE_CLICK) && e.has(Button.LEFT)) {
-                if (e.has(Modifier.SHIFT)) {
-                    addTypeToSelection(e.x, e.y, e.z > 2);
-                    displaySelectedShipInfo();
-                } else
-                if (e.has(Modifier.CTRL)) {
-                    removeTypeFromSelection(e.x, e.y, e.z > 2);
-                    displaySelectedShipInfo();
-                } else {
-                    retainTypeFromSelection(e.x, e.y, e.z > 2);
-                    displaySelectedShipInfo();
-                }
-                return true;
-            }
-            return super.mouse(e);
-        }
-        /**
-         * Add units with the same type (or category) to the current selection.
-         * @param mx the mouse coordinates
-         * @param my the mouse coordinates
-         * @param category affect entire category?
-         */
-        void addTypeToSelection(int mx, int my, boolean category) {
-            for (SelectionCell c : cells) {
-                if (c.bounds != null && c.bounds.contains(mx, my)) {
-                    for (SpacewarStructure s : structures) {
-                        if (s.owner == c.structure.owner) {
-                            if (category) {
-                                ResearchType rt0 = world().researches.get(c.structure.techId);
-                                ResearchType rt1 = world().researches.get(s.techId);
-                                s.selected = (rt0.category == rt1.category);
-                            } else {
-                                s.selected = s.techId.equals(c.structure.techId);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        /**
-         * Retain the type (or category) in the current selection.
-         * @param mx the mouse coordinates
-         * @param my the mouse coordinates
-         * @param category affect entire category?
-         */
-        void retainTypeFromSelection(int mx, int my, boolean category) {
-            for (SelectionCell c : cells) {
-                if (c.bounds != null && c.bounds.contains(mx, my)) {
-                    for (SelectionCell c1 : cells) {
-                        if (c1.structure.owner == c.structure.owner) {
-                            if (category) {
-                                ResearchType rt0 = world().researches.get(c.structure.techId);
-                                ResearchType rt1 = world().researches.get(c1.structure.techId);
-                                c1.structure.selected = (rt0.category == rt1.category);
-                            } else {
-                                c1.structure.selected = c1.structure.techId.equals(c.structure.techId);
-                            }
-                        }
-                    }
-                    break;
-                }
-            }
-
-        }
-        /**
-         * Remove the type (or category) from the current selection.
-         * @param mx the mouse coordinates
-         * @param my the mouse coordinates
-         * @param category affect entire category?
-         */
-        void removeTypeFromSelection(int mx, int my, boolean category) {
-            for (SelectionCell c : cells) {
-                if (c.bounds != null && c.bounds.contains(mx, my)) {
-                    for (SelectionCell c1 : cells) {
-                        if (c1.structure.owner == c.structure.owner) {
-                            if (category) {
-                                ResearchType rt0 = world().researches.get(c.structure.techId);
-                                ResearchType rt1 = world().researches.get(c1.structure.techId);
-                                c1.structure.selected = !(rt0.category == rt1.category);
-                            } else {
-                                c1.structure.selected = !c1.structure.techId.equals(c.structure.techId);
-                            }
-                        }
-                    }
-                    break;
-                }
-            }
-        }
-        /**
-         * Remove the cell(ship) from the selection.
-         * @param mx the mouse X
-         * @param my the mouse Y
-         */
-        void removeFromSelection(int mx, int my) {
-            for (SelectionCell c : cells) {
-                if (c.bounds != null && c.bounds.contains(mx, my)) {
-                    c.structure.selected = false;
-                }
-            }
-        }
     }
     /** Deselect everything. */
     void deselectAll() {

--- a/src/hu/openig/screen/panels/SpacewarSelectionCell.java
+++ b/src/hu/openig/screen/panels/SpacewarSelectionCell.java
@@ -1,0 +1,498 @@
+/*
+ * Copyright 2008-present, David Karnok & Contributors
+ * The file is part of the Open Imperium Galactica project.
+ *
+ * The code should be distributed under the LGPL license.
+ * See http://www.gnu.org/licenses/lgpl.html for details.
+ */
+
+package hu.openig.screen.panels;
+
+import hu.openig.model.BattleProjectile.Mode;
+import hu.openig.model.SpacewarStructure;
+import hu.openig.model.SpacewarWeaponPort;
+import hu.openig.render.TextRenderer;
+import hu.openig.render.TextRenderer.TextSegment;
+import hu.openig.screen.CommonResources;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+/**
+ * Cached display model and painter for one selected spacewar unit
+ * in the middle status panel.
+ * <p>
+ * Layout metrics are measured only when loadout/identity data changes;
+ * combat HP/shield values refresh cheaply for visible cells.
+ */
+public final class SpacewarSelectionCell {
+    /** Fixed ship icon column width. */
+    public static final int MAX_IMAGE = 50;
+    /** Gap between icon column and text. */
+    public static final int ICON_TEXT_GAP = 8;
+    /** Trailing padding after the text block. */
+    public static final int TEXT_RIGHT_PAD = 4;
+    /**
+     * Opaque-content bounds keyed by angle-frame image.
+     * Many selected units share the same {@code angles[0]} instance, so the
+     * pixel scan runs once per unique sprite.
+     */
+    static final Map<BufferedImage, Rectangle> IMAGE_CONTENT_CACHE = new WeakHashMap<>();
+
+    /** Shared resources for text measurement and painting. */
+    final CommonResources commons;
+    /** Bound structure, or {@code null} when pooled. */
+    SpacewarStructure structure;
+    /** Display name. */
+    String name = "";
+    /** Owner name. */
+    String owner = "";
+    /** Parent fleet/planet name. */
+    String parent = "";
+    /** Owner color. */
+    int color;
+    /** Ship/building image. */
+    BufferedImage image;
+    /** Shield fill ratio, or {@code -1} when none. */
+    double shieldRatio;
+    /** HP fill ratio. */
+    double hpRatio;
+    /** Total beam firepower. */
+    double firepower;
+    /** Damage per second. */
+    double dps;
+    /** Rocket count. */
+    int rockets;
+    /** Bomb count. */
+    int bombs;
+    /** Unit batch count. */
+    int count;
+    /** Current HP. */
+    int hp;
+    /** Current shield points, or {@code -1}. */
+    int sp;
+    /** Last HP baked into defense segments. */
+    int defenseHp = Integer.MIN_VALUE;
+    /** Last shield baked into defense segments. */
+    int defenseSp = Integer.MIN_VALUE;
+    /** Name caption (no colon). */
+    String nameCaption = "";
+    /** Name value. */
+    String nameValue = "";
+    /** Owner caption (no colon). */
+    String ownerCaption = "";
+    /** Owner value. */
+    String ownerValue = "";
+    /** Parent caption (no colon). */
+    String parentCaption = "";
+    /** Parent value. */
+    String parentValue = "";
+    /** Firepower caption (no colon). */
+    String firepowerCaption = "";
+    /** Firepower value. */
+    String firepowerValue = "";
+    /** Bombs/rockets caption (no colon), or {@code null}. */
+    String bombsRocketsCaption;
+    /** Bombs/rockets value, or {@code null}. */
+    String bombsRocketsValue;
+    /** Defense caption (no colon). */
+    String defenseCaption = "";
+    /** Width of the widest "{@code caption: }" among this cell's lines. */
+    int captionColumnWidth;
+    /** Measured cell width. */
+    int cellWidth;
+    /** Measured cell height. */
+    int cellHeight;
+    /** Text block height. */
+    int textHeight;
+    /** X within the current layout row. */
+    int rowX;
+    /** True when painted in the current viewport. */
+    boolean visibleInViewport;
+    /** Hit-test bounds in panel coordinates. */
+    final Rectangle bounds = new Rectangle();
+    /** Opaque pixel bounds of {@link #image} (source coordinates). */
+    final Rectangle imageContent = new Rectangle();
+    /** Drawn width of the opaque ship art. */
+    int iconDrawW;
+    /** Drawn height of the opaque ship art. */
+    int iconDrawH;
+    /** Reused defense-value segments (no caption). */
+    final List<TextSegment> defenseSegments = new ArrayList<>(5);
+
+    /**
+     * @param commons the common resources
+     */
+    public SpacewarSelectionCell(CommonResources commons) {
+        this.commons = commons;
+    }
+
+    /**
+     * Bind to a structure and fully recompute cached display data.
+     * @param s the structure
+     */
+    public void bind(SpacewarStructure s) {
+        this.structure = s;
+        image = s.angles[0];
+        computeImageContentBounds();
+        if (s.item != null) {
+            name = s.item.type.name;
+        } else if (s.building != null) {
+            name = s.building.type.name;
+        } else {
+            name = "";
+        }
+        owner = s.owner.name;
+        color = s.owner.color;
+        if (s.fleet != null) {
+            parent = s.fleet.name();
+        } else if (s.planet != null) {
+            parent = s.planet.name();
+        } else {
+            parent = "";
+        }
+        defenseCaption = stripCaption(commons.labels().get("spacewar.selection.defense_values"));
+        String[] ownerParts = splitLabeled(commons.labels().format("spacewar.selection.owner", owner));
+        ownerCaption = ownerParts[0];
+        ownerValue = ownerParts[1];
+        String[] parentParts = splitLabeled(commons.labels().format("spacewar.selection.parent", parent));
+        parentCaption = parentParts[0];
+        parentValue = parentParts[1];
+        defenseHp = Integer.MIN_VALUE;
+        defenseSp = Integer.MIN_VALUE;
+        refreshCombatStats();
+        recomputeLoadoutAndSize();
+        rebuildDefenseSegments();
+    }
+
+    /**
+     * Re-read weapon loadout / count and remeasure.
+     * @return true if layout size changed
+     */
+    public boolean recomputeLoadoutAndSize() {
+        int prevW = cellWidth;
+        int prevH = cellHeight;
+
+        count = structure.count;
+        firepower = 0;
+        dps = 0;
+        rockets = 0;
+        bombs = 0;
+        for (SpacewarWeaponPort p : structure.ports) {
+            if (p.projectile.mode == Mode.BEAM) {
+                double dmg = p.damage(structure.owner);
+                firepower += p.count * dmg * count;
+                dps += p.count * dmg * count * 1000.0 / p.projectile.delay;
+            } else if (p.projectile.mode == Mode.ROCKET || p.projectile.mode == Mode.MULTI_ROCKET) {
+                rockets += p.count;
+            } else if (p.projectile.mode == Mode.BOMB || p.projectile.mode == Mode.VIRUS) {
+                bombs += p.count;
+            }
+        }
+        dps = Math.round(dps);
+
+        String[] nameParts;
+        if (count > 1) {
+            nameParts = splitLabeled(commons.labels().format("spacewar.selection.name_count", name, count));
+        } else {
+            nameParts = splitLabeled(commons.labels().format("spacewar.selection.name", name));
+        }
+        nameCaption = nameParts[0];
+        nameValue = nameParts[1];
+
+        String[] fpParts = splitLabeled(commons.labels().format(
+                "spacewar.selection.firepower_dps", (int)firepower, (int)dps));
+        firepowerCaption = fpParts[0];
+        firepowerValue = fpParts[1];
+
+        if (rockets > 0 || bombs > 0) {
+            String[] brParts = splitLabeled(commons.labels().format(
+                    "spacewar.selection.bombs_rockets", bombs, rockets));
+            bombsRocketsCaption = brParts[0];
+            bombsRocketsValue = brParts[1];
+        } else {
+            bombsRocketsCaption = null;
+            bombsRocketsValue = null;
+        }
+
+        int rows = bombsRocketsCaption != null ? 6 : 5;
+        textHeight = 7 * rows + (rows - 1) * 2;
+
+        TextRenderer tr = commons.text();
+        captionColumnWidth = 0;
+        captionColumnWidth = Math.max(captionColumnWidth, captionWidth(tr, nameCaption));
+        captionColumnWidth = Math.max(captionColumnWidth, captionWidth(tr, ownerCaption));
+        captionColumnWidth = Math.max(captionColumnWidth, captionWidth(tr, parentCaption));
+        captionColumnWidth = Math.max(captionColumnWidth, captionWidth(tr, firepowerCaption));
+        if (bombsRocketsCaption != null) {
+            captionColumnWidth = Math.max(captionColumnWidth, captionWidth(tr, bombsRocketsCaption));
+        }
+        captionColumnWidth = Math.max(captionColumnWidth, captionWidth(tr, defenseCaption));
+
+        int w = 0;
+        w = Math.max(w, valueWidth(tr, nameValue));
+        w = Math.max(w, valueWidth(tr, ownerValue));
+        w = Math.max(w, valueWidth(tr, parentValue));
+        w = Math.max(w, valueWidth(tr, firepowerValue));
+        if (bombsRocketsValue != null) {
+            w = Math.max(w, valueWidth(tr, bombsRocketsValue));
+        }
+        // Size defense values for worst-case digits so HP ticks do not force relayout.
+        int dv = tr.getTextWidth(7, Integer.toString(Math.max(hp, structure.hpMax)));
+        if (structure.shieldMax > 0) {
+            dv += tr.getTextWidth(7, " + ");
+            dv += tr.getTextWidth(7, Integer.toString(Math.max(sp, (int)structure.shieldMax)));
+            dv += tr.getTextWidth(7, " = ");
+            dv += tr.getTextWidth(7, Integer.toString(
+                    Math.max(hp, structure.hpMax) + Math.max(sp, (int)structure.shieldMax)));
+        }
+        w = Math.max(w, dv);
+
+        refreshIconDrawSize();
+        cellWidth = MAX_IMAGE + ICON_TEXT_GAP + captionColumnWidth + w + TEXT_RIGHT_PAD;
+        // Bars share the text top; ship sits in the remaining text height.
+        cellHeight = Math.max(10 + iconDrawH, textHeight + 2);
+        return prevW != cellWidth || prevH != cellHeight;
+    }
+
+    /** Update HP / shield display values from the live structure. */
+    public void refreshCombatStats() {
+        hp = (int)structure.hp;
+        hpRatio = structure.hpMax > 0 ? structure.hp / structure.hpMax : 0;
+        if (structure.shieldMax > 0) {
+            shieldRatio = structure.shield / structure.shieldMax;
+            sp = (int)structure.shield;
+        } else {
+            shieldRatio = -1;
+            sp = -1;
+        }
+    }
+
+    /**
+     * Sync loadout that affects labels.
+     * @return true if cell size changed and layout must run
+     */
+    public boolean syncLoadout() {
+        int newRockets = 0;
+        int newBombs = 0;
+        for (SpacewarWeaponPort p : structure.ports) {
+            if (p.projectile.mode == Mode.ROCKET || p.projectile.mode == Mode.MULTI_ROCKET) {
+                newRockets += p.count;
+            } else if (p.projectile.mode == Mode.BOMB || p.projectile.mode == Mode.VIRUS) {
+                newBombs += p.count;
+            }
+        }
+        if (structure.count != count || newRockets != rockets || newBombs != bombs) {
+            return recomputeLoadoutAndSize();
+        }
+        return false;
+    }
+
+    /** Rebuild colored defense-value segments when HP / shield text changed. */
+    public void rebuildDefenseSegments() {
+        if (defenseHp == hp && defenseSp == sp) {
+            return;
+        }
+        defenseHp = hp;
+        defenseSp = sp;
+        defenseSegments.clear();
+        defenseSegments.add(new TextSegment(Integer.toString(hp), Color.GREEN.getRGB()));
+        if (sp >= 0) {
+            defenseSegments.add(new TextSegment(" + ", color));
+            defenseSegments.add(new TextSegment(Integer.toString(sp), Color.ORANGE.getRGB()));
+            defenseSegments.add(new TextSegment(" = ", color));
+            defenseSegments.add(new TextSegment(Integer.toString(hp + sp), TextRenderer.YELLOW));
+        }
+    }
+
+    /**
+     * Paint the cell at the given origin.
+     * @param g2 the graphics context
+     * @param x0 origin X
+     * @param y0 origin Y
+     */
+    public void paint(Graphics2D g2, int x0, int y0) {
+        g2.translate(x0, y0);
+
+        // Bars share the first text line; both start at the top of the cell.
+        int ty = 0;
+        int barY = 0;
+
+        g2.setColor(Color.GREEN);
+        int iw2 = (int)(MAX_IMAGE * hpRatio);
+        g2.drawRect(0, barY, MAX_IMAGE, 4);
+        g2.fillRect(0, barY, iw2, 4);
+
+        if (shieldRatio >= 0) {
+            g2.setColor(Color.ORANGE);
+            iw2 = (int)(MAX_IMAGE * shieldRatio);
+            g2.drawRect(0, barY + 6, MAX_IMAGE, 4);
+            g2.fillRect(0, barY + 6, iw2, 4);
+        }
+
+        // Ship centered in the space below the bars.
+        int belowTop = barY + 10;
+        int belowH = Math.max(0, cellHeight - belowTop);
+        int iy = belowTop + Math.max(0, (belowH - iconDrawH) / 2);
+        int ix = (MAX_IMAGE - iconDrawW) / 2;
+        g2.drawImage(
+                image,
+                ix, iy, ix + iconDrawW, iy + iconDrawH,
+                imageContent.x, imageContent.y,
+                imageContent.x + imageContent.width, imageContent.y + imageContent.height,
+                null);
+
+        int labelX = MAX_IMAGE + ICON_TEXT_GAP;
+        int valueX = labelX + captionColumnWidth;
+
+        TextRenderer tr = commons.text();
+        paintLabeled(tr, g2, labelX, valueX, ty, nameCaption, nameValue);
+        paintLabeled(tr, g2, labelX, valueX, ty + 9, ownerCaption, ownerValue);
+        paintLabeled(tr, g2, labelX, valueX, ty + 18, parentCaption, parentValue);
+        paintLabeled(tr, g2, labelX, valueX, ty + 27, firepowerCaption, firepowerValue);
+        int y2 = ty + 36;
+        if (bombsRocketsCaption != null) {
+            paintLabeled(tr, g2, labelX, valueX, y2, bombsRocketsCaption, bombsRocketsValue);
+            y2 += 9;
+        }
+        tr.paintTo(g2, labelX, y2, 7, color, defenseCaption + ": ");
+        tr.paintTo(g2, valueX, y2, 7, defenseSegments);
+
+        g2.translate(-x0, -y0);
+    }
+
+    /** Resolve opaque bounds for {@link #image}, using a shared sprite cache. */
+    void computeImageContentBounds() {
+        Rectangle cached = IMAGE_CONTENT_CACHE.get(image);
+        if (cached != null) {
+            imageContent.setBounds(cached);
+            return;
+        }
+        Rectangle scanned = scanOpaqueBounds(image);
+        IMAGE_CONTENT_CACHE.put(image, scanned);
+        imageContent.setBounds(scanned);
+    }
+
+    /**
+     * Bulk-scan non-transparent pixels of an angle frame.
+     * @param img the sprite frame
+     * @return opaque content bounds in image coordinates
+     */
+    static Rectangle scanOpaqueBounds(BufferedImage img) {
+        int w = img.getWidth();
+        int h = img.getHeight();
+        int[] pixels = new int[w * h];
+        img.getRGB(0, 0, w, h, pixels, 0, w);
+
+        int top = h;
+        int bottom = -1;
+        int left = w;
+        int right = -1;
+        for (int y = 0; y < h; y++) {
+            int row = y * w;
+            for (int x = 0; x < w; x++) {
+                if ((pixels[row + x] >>> 24) != 0) {
+                    if (y < top) {
+                        top = y;
+                    }
+                    if (y > bottom) {
+                        bottom = y;
+                    }
+                    if (x < left) {
+                        left = x;
+                    }
+                    if (x > right) {
+                        right = x;
+                    }
+                }
+            }
+        }
+        if (bottom < 0) {
+            return new Rectangle(0, 0, w, h);
+        }
+        return new Rectangle(left, top, right - left + 1, bottom - top + 1);
+    }
+
+    /**
+     * Scale the opaque ship art into {@link #MAX_IMAGE}.
+     */
+    void refreshIconDrawSize() {
+        double scale = Math.min(
+                1.0 * MAX_IMAGE / imageContent.width,
+                1.0 * MAX_IMAGE / imageContent.height);
+        if (scale > 1) {
+            scale = 1;
+        }
+        iconDrawW = Math.max(1, (int)(imageContent.width * scale));
+        iconDrawH = Math.max(1, (int)(imageContent.height * scale));
+    }
+
+    /**
+     * Split a {@code "Caption : value"} label into caption and value.
+     * @param formatted the localized formatted line
+     * @return {@code [caption, value]}
+     */
+    static String[] splitLabeled(String formatted) {
+        int i = formatted.indexOf(':');
+        if (i < 0) {
+            return new String[] { formatted.trim(), "" };
+        }
+        return new String[] {
+            formatted.substring(0, i).trim(),
+            formatted.substring(i + 1).trim()
+        };
+    }
+
+    /**
+     * Strip trailing colon / spaces from a caption-only label.
+     * @param caption the localized caption
+     * @return caption without trailing {@code :}
+     */
+    static String stripCaption(String caption) {
+        String s = caption.trim();
+        if (s.endsWith(":")) {
+            s = s.substring(0, s.length() - 1).trim();
+        }
+        return s;
+    }
+
+    /**
+     * @param tr text renderer
+     * @param caption label caption
+     * @return width of {@code caption + ": "}
+     */
+    static int captionWidth(TextRenderer tr, String caption) {
+        return tr.getTextWidth(7, caption + ": ");
+    }
+
+    /**
+     * @param tr text renderer
+     * @param value label value
+     * @return value text width
+     */
+    static int valueWidth(TextRenderer tr, String value) {
+        return tr.getTextWidth(7, value);
+    }
+
+    /**
+     * Paint a caption/value pair with a shared value column.
+     * @param tr text renderer
+     * @param g2 graphics
+     * @param labelX caption origin X
+     * @param valueX value origin X
+     * @param y baseline Y
+     * @param caption caption without colon
+     * @param value value text
+     */
+    void paintLabeled(TextRenderer tr, Graphics2D g2, int labelX, int valueX, int y,
+            String caption, String value) {
+        tr.paintTo(g2, labelX, y, 7, color, caption + ": ");
+        tr.paintTo(g2, valueX, y, 7, color, value);
+    }
+}

--- a/src/hu/openig/screen/panels/SpacewarSelectionPanel.java
+++ b/src/hu/openig/screen/panels/SpacewarSelectionPanel.java
@@ -1,0 +1,557 @@
+/*
+ * Copyright 2008-present, David Karnok & Contributors
+ * The file is part of the Open Imperium Galactica project.
+ *
+ * The code should be distributed under the LGPL license.
+ * See http://www.gnu.org/licenses/lgpl.html for details.
+ */
+
+package hu.openig.screen.panels;
+
+import hu.openig.core.Action0;
+import hu.openig.core.Action1;
+import hu.openig.model.ResearchType;
+import hu.openig.model.SpacewarStructure;
+import hu.openig.render.TextRenderer;
+import hu.openig.screen.CommonResources;
+import hu.openig.ui.UIImageButton;
+import hu.openig.ui.UIMouse;
+import hu.openig.ui.UIMouse.Button;
+import hu.openig.ui.UIMouse.Modifier;
+import hu.openig.ui.UIMouse.Type;
+import hu.openig.ui.UIPanel;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.Shape;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Spacewar middle status panel: group buttons + scrollable selection grid.
+ * <p>
+ * Structure:
+ * <ul>
+ * <li>{@link #groupBar} — fixed top strip of group recall buttons</li>
+ * <li>{@link #content} — layout, caching, and atomic offscreen painting of cells</li>
+ * </ul>
+ * Layout runs only when the selection set, loadout sizes, or panel width change.
+ * The visible page is composed into a buffer then blitted once so icons and
+ * labels never update out of sync while scrolling.
+ */
+public class SpacewarSelectionPanel extends UIPanel {
+    /** Top of the scrollable cell area (below group buttons). */
+    public static final int CONTENT_TOP = 22;
+    /** Horizontal inset for the cell grid (matches group-button start). */
+    public static final int CONTENT_PAD_X = 5;
+    /** Vertical inset inside the scrollable cell area. */
+    public static final int CONTENT_PAD_Y = 3;
+    /** Gap between cells in the selection grid. */
+    public static final int CELL_GAP = 4;
+
+    /** Common resources. */
+    final CommonResources commons;
+    /** Group button strip. */
+    final UIPanel groupBar;
+    /** Scrollable / virtualized cell viewport. */
+    final ContentPanel content;
+    /** Group buttons; index 0 is select-all (*), 1..10 are groups 0..9. */
+    final List<UIImageButton> groupButtons = new ArrayList<>();
+    /** Reusable group-presence flags. */
+    final boolean[] groupPresent = new boolean[11];
+
+    /** Live battle structures (owner keeps the list). */
+    public List<SpacewarStructure> structures;
+    /** Control-group map (owner keeps the map). */
+    public Map<SpacewarStructure, Integer> groups;
+
+    /** Select-all action. */
+    public Action0 onSelectAll;
+    /** Deselect-all action (right-click *). */
+    public Action0 onDeselectAll;
+    /** Recall control group. */
+    public Action1<Integer> onRecallGroup;
+    /** Remove control group. */
+    public Action1<Integer> onRemoveGroup;
+    /** Called after local selection edits (right-click / double-click filters). */
+    public Action0 onSelectionModified;
+
+    /**
+     * @param commons the common resources
+     */
+    public SpacewarSelectionPanel(CommonResources commons) {
+        this.commons = commons;
+        backgroundColor(0xFF000000);
+
+        groupBar = new UIPanel();
+        groupBar.location(0, 0);
+        groupBar.height = CONTENT_TOP;
+
+        content = new ContentPanel();
+        content.location(0, CONTENT_TOP);
+
+        buildGroupButtons();
+
+        add(groupBar, content);
+    }
+
+    /** Create the * / 0..9 group buttons. */
+    void buildGroupButtons() {
+        int x = 5;
+        for (int i = -1; i < 10; i++) {
+            final int j = i;
+            UIImageButton ib = new UIImageButton(commons.common().shield) {
+                @Override
+                public void draw(Graphics2D g2) {
+                    super.draw(g2);
+                    String s = j < 0 ? "*" : Integer.toString(j);
+                    commons.text().paintTo(g2, 7, 3, 10, TextRenderer.WHITE, s);
+                }
+                @Override
+                public boolean mouse(UIMouse e) {
+                    if (e.has(Button.RIGHT) && e.has(Type.DOWN)) {
+                        if (j >= 0) {
+                            if (onRemoveGroup != null) {
+                                onRemoveGroup.invoke(j);
+                            }
+                        } else if (onDeselectAll != null) {
+                            onDeselectAll.invoke();
+                        }
+                        return true;
+                    }
+                    return super.mouse(e);
+                }
+            };
+            ib.onClick = new Action0() {
+                @Override
+                public void invoke() {
+                    if (j >= 0) {
+                        if (onRecallGroup != null) {
+                            onRecallGroup.invoke(j);
+                        }
+                    } else if (onSelectAll != null) {
+                        onSelectAll.invoke();
+                    }
+                }
+            };
+            if (i == -1) {
+                ib.tooltip(commons.labels().get("battle.selectall.tooltip"));
+            } else {
+                ib.tooltip(commons.labels().format("battle.selectgroup.tooltip", i));
+            }
+            ib.x = x;
+            x += 25;
+            groupButtons.add(ib);
+            groupBar.add(ib);
+        }
+    }
+
+    @Override
+    public void size(int width, int height) {
+        super.size(width, height);
+        groupBar.size(width, CONTENT_TOP);
+        content.size(Math.max(0, width), Math.max(0, height - CONTENT_TOP));
+        content.invalidateLayout();
+    }
+
+    @Override
+    public void draw(Graphics2D g2) {
+        updateGroupButtons();
+        content.syncAndLayout();
+        super.draw(g2);
+    }
+
+    @Override
+    public boolean mouse(UIMouse e) {
+        // Wheel works over the whole panel (including the group strip).
+        if (e.has(Type.WHEEL)) {
+            content.syncFromSelection();
+            int prev = content.offset;
+            if (e.z < 0) {
+                content.offset--;
+            } else {
+                content.offset++;
+            }
+            content.clampOffset();
+            return content.offset != prev;
+        }
+        return super.mouse(e);
+    }
+
+    /** Update group-button visibility from the current group map. */
+    void updateGroupButtons() {
+        Arrays.fill(groupPresent, false);
+        groupPresent[0] = true;
+        if (groups != null) {
+            for (Integer g : groups.values()) {
+                if (g != null && g >= 0 && g < 10) {
+                    groupPresent[g + 1] = true;
+                }
+            }
+        }
+        for (int i = 0; i < 11; i++) {
+            boolean v0 = groupButtons.get(i).visible();
+            groupButtons.get(i).visible(groupPresent[i]);
+            if (v0 != groupPresent[i]) {
+                commons.control().moveMouse();
+            }
+        }
+    }
+
+    /**
+     * Clear selection view state (keeps group buttons).
+     * Does not remove child components.
+     */
+    public void clear() {
+        content.clearContents();
+    }
+
+    /** One wrap-row of selection cells. */
+    static final class SelectionRow {
+        /** Cells in left-to-right order. */
+        final List<SpacewarSelectionCell> cells = new ArrayList<>();
+        /** Row height in pixels. */
+        int height;
+    }
+
+    /**
+     * Scrollable viewport: owns cell pool, row layout, and atomic buffer paint.
+     */
+    final class ContentPanel extends UIPanel {
+        /** Scroll offset in layout rows. */
+        int offset;
+        /** Max scroll offset. */
+        int maxOffset;
+        /** Width used by the last layout. */
+        int layoutWidth = -1;
+        /** True when rows must be recomputed. */
+        boolean layoutDirty = true;
+        /** Offscreen buffer for the visible page. */
+        BufferedImage contentBuffer;
+        /** Scratch list of the current selection. */
+        final List<SpacewarStructure> selectionScratch = new ArrayList<>();
+        /** Bound cells in display order. */
+        final List<SpacewarSelectionCell> cells = new ArrayList<>();
+        /** Recycled cells. */
+        final List<SpacewarSelectionCell> cellPool = new ArrayList<>();
+        /** Laid-out rows. */
+        final List<SelectionRow> rows = new ArrayList<>();
+        /** Recycled rows. */
+        final List<SelectionRow> rowPool = new ArrayList<>();
+        ContentPanel() {
+            backgroundColor(0xFF000000);
+        }
+
+        /** Mark layout dirty (e.g. after resize). */
+        void invalidateLayout() {
+            layoutDirty = true;
+        }
+
+        /** Release cell/row state. */
+        void clearContents() {
+            selectionScratch.clear();
+            for (SpacewarSelectionCell c : cells) {
+                c.structure = null;
+                c.visibleInViewport = false;
+                cellPool.add(c);
+            }
+            cells.clear();
+            for (SelectionRow r : rows) {
+                r.cells.clear();
+                rowPool.add(r);
+            }
+            rows.clear();
+            offset = 0;
+            maxOffset = 0;
+            layoutWidth = -1;
+            layoutDirty = true;
+            contentBuffer = null;
+        }
+
+        /** Sync selection, layout if needed, then paint the buffer. */
+        void syncAndLayout() {
+            syncFromSelection();
+            renderContentBuffer();
+        }
+
+        void collectSelection() {
+            selectionScratch.clear();
+            if (structures == null) {
+                return;
+            }
+            for (SpacewarStructure s : structures) {
+                if (s.selected) {
+                    selectionScratch.add(s);
+                }
+            }
+        }
+
+        boolean selectionMatchesCells() {
+            if (selectionScratch.size() != cells.size()) {
+                return false;
+            }
+            for (int i = 0; i < cells.size(); i++) {
+                if (cells.get(i).structure != selectionScratch.get(i)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        void rebuildCells() {
+            for (SpacewarSelectionCell c : cells) {
+                c.structure = null;
+                c.visibleInViewport = false;
+                cellPool.add(c);
+            }
+            cells.clear();
+            for (SpacewarStructure s : selectionScratch) {
+                SpacewarSelectionCell c;
+                if (!cellPool.isEmpty()) {
+                    c = cellPool.remove(cellPool.size() - 1);
+                } else {
+                    c = new SpacewarSelectionCell(commons);
+                }
+                c.bind(s);
+                cells.add(c);
+            }
+            layoutDirty = true;
+        }
+
+        void syncFromSelection() {
+            collectSelection();
+            if (!selectionMatchesCells()) {
+                offset = 0;
+                rebuildCells();
+            } else {
+                for (SpacewarSelectionCell c : cells) {
+                    if (c.syncLoadout()) {
+                        layoutDirty = true;
+                    }
+                }
+            }
+            if (layoutWidth != width) {
+                layoutDirty = true;
+            }
+            if (layoutDirty) {
+                layoutRows();
+            }
+        }
+
+        /** Flow cells into wrap-rows for the current width. */
+        void layoutRows() {
+            for (SelectionRow r : rows) {
+                r.cells.clear();
+                r.height = 0;
+                rowPool.add(r);
+            }
+            rows.clear();
+
+            int innerWidth = Math.max(0, width - 2 * CONTENT_PAD_X);
+            SelectionRow current = null;
+            int x0 = 0;
+            for (SpacewarSelectionCell c : cells) {
+                c.visibleInViewport = false;
+                if (current != null && x0 > 0 && x0 + c.cellWidth >= innerWidth) {
+                    rows.add(current);
+                    current = null;
+                    x0 = 0;
+                }
+                if (current == null) {
+                    if (!rowPool.isEmpty()) {
+                        current = rowPool.remove(rowPool.size() - 1);
+                    } else {
+                        current = new SelectionRow();
+                    }
+                }
+                current.cells.add(c);
+                c.rowX = CONTENT_PAD_X + x0;
+                current.height = Math.max(current.height, c.cellHeight);
+                x0 += c.cellWidth + CELL_GAP;
+            }
+            if (current != null && !current.cells.isEmpty()) {
+                rows.add(current);
+            }
+
+            layoutWidth = width;
+            layoutDirty = false;
+            clampOffset();
+        }
+
+        void clampOffset() {
+            if (rows.isEmpty()) {
+                offset = 0;
+                maxOffset = 0;
+                return;
+            }
+
+            maxOffset = Math.max(0, rows.size() - 1);
+            if (offset < 0) {
+                offset = 0;
+            } else if (offset > maxOffset) {
+                offset = maxOffset;
+            }
+        }
+
+        int ensureContentBuffer() {
+            int bw = Math.max(1, width);
+            int bh = Math.max(1, height);
+            if (contentBuffer == null
+                    || contentBuffer.getWidth() != bw
+                    || contentBuffer.getHeight() != bh) {
+                contentBuffer = new BufferedImage(bw, bh, BufferedImage.TYPE_INT_ARGB);
+            }
+            return bh;
+        }
+
+        /**
+         * Compose the visible page into {@link #contentBuffer}.
+         * Icons, bars and labels for every visible cell are painted here
+         * before a single blit in {@link #draw(Graphics2D)}.
+         */
+        void renderContentBuffer() {
+            int viewH = ensureContentBuffer();
+            Graphics2D bg = contentBuffer.createGraphics();
+            try {
+                bg.setColor(Color.BLACK);
+                bg.fillRect(0, 0, contentBuffer.getWidth(), viewH);
+
+                for (SpacewarSelectionCell c : cells) {
+                    c.visibleInViewport = false;
+                }
+
+                int y0 = CONTENT_PAD_Y;
+                int viewBottom = viewH - CONTENT_PAD_Y;
+                for (int r = offset; r < rows.size(); r++) {
+                    SelectionRow row = rows.get(r);
+                    if (y0 >= viewBottom) {
+                        break;
+                    }
+                    for (SpacewarSelectionCell c : row.cells) {
+                        c.refreshCombatStats();
+                        c.rebuildDefenseSegments();
+                        c.visibleInViewport = true;
+                        // Bounds in parent (SpacewarSelectionPanel) coordinates.
+                        c.bounds.setBounds(c.rowX, CONTENT_TOP + y0, c.cellWidth, c.cellHeight);
+                        c.paint(bg, c.rowX, y0);
+                    }
+                    y0 += row.height + CELL_GAP;
+                }
+            } finally {
+                bg.dispose();
+            }
+        }
+
+        @Override
+        public void draw(Graphics2D g2) {
+            // Buffer already prepared in syncAndLayout() during parent draw.
+            Shape save = g2.getClip();
+            g2.clipRect(0, 0, width, height);
+            g2.drawImage(contentBuffer, 0, 0, null);
+            g2.setClip(save);
+        }
+
+        @Override
+        public boolean mouse(UIMouse e) {
+            // Coordinates are content-local; convert to panel-local for bounds.
+            int mx = e.x;
+            int my = e.y + CONTENT_TOP;
+            if (e.has(Type.DOWN) && e.has(Button.RIGHT)) {
+                removeFromSelection(mx, my);
+                fireSelectionModified();
+                return true;
+            }
+            if (e.has(Type.DOUBLE_CLICK) && e.has(Button.LEFT)) {
+                if (e.has(Modifier.SHIFT)) {
+                    addTypeToSelection(mx, my, e.z > 2);
+                } else if (e.has(Modifier.CTRL)) {
+                    removeTypeFromSelection(mx, my, e.z > 2);
+                } else {
+                    retainTypeFromSelection(mx, my, e.z > 2);
+                }
+                fireSelectionModified();
+                return true;
+            }
+            return super.mouse(e);
+        }
+
+        void fireSelectionModified() {
+            if (onSelectionModified != null) {
+                onSelectionModified.invoke();
+            }
+        }
+
+        SpacewarSelectionCell cellAt(int mx, int my) {
+            for (SpacewarSelectionCell c : cells) {
+                if (c.visibleInViewport && c.bounds.contains(mx, my)) {
+                    return c;
+                }
+            }
+            return null;
+        }
+
+        void addTypeToSelection(int mx, int my, boolean category) {
+            SpacewarSelectionCell c = cellAt(mx, my);
+            if (c == null || structures == null) {
+                return;
+            }
+            for (SpacewarStructure s : structures) {
+                if (s.owner == c.structure.owner) {
+                    if (category) {
+                        ResearchType rt0 = commons.world().researches.get(c.structure.techId);
+                        ResearchType rt1 = commons.world().researches.get(s.techId);
+                        s.selected = rt0.category == rt1.category;
+                    } else {
+                        s.selected = s.techId.equals(c.structure.techId);
+                    }
+                }
+            }
+        }
+
+        void retainTypeFromSelection(int mx, int my, boolean category) {
+            SpacewarSelectionCell c = cellAt(mx, my);
+            if (c == null) {
+                return;
+            }
+            for (SpacewarSelectionCell c1 : cells) {
+                if (c1.structure.owner == c.structure.owner) {
+                    if (category) {
+                        ResearchType rt0 = commons.world().researches.get(c.structure.techId);
+                        ResearchType rt1 = commons.world().researches.get(c1.structure.techId);
+                        c1.structure.selected = rt0.category == rt1.category;
+                    } else {
+                        c1.structure.selected = c1.structure.techId.equals(c.structure.techId);
+                    }
+                }
+            }
+        }
+
+        void removeTypeFromSelection(int mx, int my, boolean category) {
+            SpacewarSelectionCell c = cellAt(mx, my);
+            if (c == null) {
+                return;
+            }
+            for (SpacewarSelectionCell c1 : cells) {
+                if (c1.structure.owner == c.structure.owner) {
+                    if (category) {
+                        ResearchType rt0 = commons.world().researches.get(c.structure.techId);
+                        ResearchType rt1 = commons.world().researches.get(c1.structure.techId);
+                        c1.structure.selected = rt0.category != rt1.category;
+                    } else {
+                        c1.structure.selected = !c1.structure.techId.equals(c.structure.techId);
+                    }
+                }
+            }
+        }
+
+        void removeFromSelection(int mx, int my) {
+            SpacewarSelectionCell c = cellAt(mx, my);
+            if (c != null) {
+                c.structure.selected = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Rework the spacewar middle selection UI into `SpacewarSelectionPanel` / `SpacewarSelectionCell` with dirty-gated layout, cell pooling, viewport virtualization, and atomic offscreen blitting (fixes #1221).
- Polish cell layout: panel padding, cell gutters, colon-aligned labels, fixed icon column
- Add `SpacewarStructure.isInRange` / `distanceTo` and use them for guard/auto-target checks so yes/no range tests no longer allocate port lists.

## Tested
- Select many ships in spacewar; FPS should stay usable with the middle panel fully visible
- Scroll the middle panel
- Ctrl+0–9 assign / Shift+0–9 recall / group buttons / right-click remove / double-click type filters still work
- Verify cell layout: padding, gutters, aligned colons, alignment
- Confirm HP/shield/DPS update live without panel stutter
- Select a large same-type fleet (cache path) and a mixed fleet; icons/cropping still look correct


Note: AI assistance was utilized during the process to fix this issue.

Fixes https://github.com/akarnokd/open-ig/issues/1221