### PR TITLE
Keep engaging rockets that temporarily leave the battlefield.

### DIFF
--- a/src/hu/openig/screen/items/SpacewarScreen.java
+++ b/src/hu/openig/screen/items/SpacewarScreen.java
@@ -4067,7 +4067,8 @@ public class SpacewarScreen extends ScreenBase implements SpacewarWorld {
                 if (ship.attackUnit != null && !ship.flee) {
                     if (ship.attackUnit.isDestroyed()
                             || (ship.guard && ship.inRange(ship.attackUnit).isEmpty())
-                            || (!ship.attackUnit.intersects(0, 0, space.width, space.height))) {
+                            || (!ship.attackUnit.isRocket()
+                                    && !ship.attackUnit.intersects(0, 0, space.width, space.height))) {
                         guard(ship);
                         if (ship.selected && ship.owner == player()) {
                             enableSelectedFleetControls();


### PR DESCRIPTION
## Summary
- Fixes #1219: ships no longer stop firing at rockets/bombs that leave the battle rectangle while turning back.
- The out-of-bounds target drop still applies to normal ships (e.g. fled units), so retreat behavior is unchanged.

## Test plan
- Fire rockets/bombs that leave the battlefield while turning (tested with a debug flag); confirm ships keep shooting at them the whole time
- Confirm ships resume correctly when a rocket re-enters the battlefield
- Confirm fleeing ships that leave the map still stop being targeted
- Confirm rocket impact / ECM / multi-rocket behavior is unchanged


Fixes #1219