### PR TITLE
Improve spacewar selection panel scrolling and visible-cell work

### DIFF
--- a/src/hu/openig/screen/panels/SpacewarSelectionCell.java
+++ b/src/hu/openig/screen/panels/SpacewarSelectionCell.java
@@ -113,8 +113,6 @@ public final class SpacewarSelectionCell {
     int textHeight;
     /** X within the current layout row. */
     int rowX;
-    /** True when painted in the current viewport. */
-    boolean visibleInViewport;
     /** Hit-test bounds in panel coordinates. */
     final Rectangle bounds = new Rectangle();
     /** Opaque pixel bounds of {@link #image} (source coordinates). */

--- a/src/hu/openig/screen/panels/SpacewarSelectionPanel.java
+++ b/src/hu/openig/screen/panels/SpacewarSelectionPanel.java
@@ -23,6 +23,7 @@ import hu.openig.ui.UIPanel;
 
 import java.awt.Color;
 import java.awt.Graphics2D;
+import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
@@ -52,6 +53,14 @@ public class SpacewarSelectionPanel extends UIPanel {
     public static final int CONTENT_PAD_Y = 3;
     /** Gap between cells in the selection grid. */
     public static final int CELL_GAP = 4;
+    /** Overlay scrollbar width. */
+    static final int SCROLL_BAR_WIDTH = 8;
+    /** Minimum scrollbar thumb height. */
+    static final int SCROLL_MIN_THUMB = 12;
+    /** Scrollbar track color. */
+    static final Color SCROLL_TRACK = new Color(0x40, 0x40, 0x40);
+    /** Scrollbar thumb color. */
+    static final Color SCROLL_THUMB = new Color(0xA0, 0xA0, 0xA0);
 
     /** Common resources. */
     final CommonResources commons;
@@ -242,6 +251,14 @@ public class SpacewarSelectionPanel extends UIPanel {
         final List<SelectionRow> rows = new ArrayList<>();
         /** Recycled rows. */
         final List<SelectionRow> rowPool = new ArrayList<>();
+        /** Scrollbar track (content-local). */
+        final Rectangle scrollTrack = new Rectangle();
+        /** Scrollbar thumb (content-local). */
+        final Rectangle scrollThumb = new Rectangle();
+        /** True while dragging the scrollbar thumb. */
+        boolean scrollDragging;
+        /** Grab offset within the thumb when drag started. */
+        int scrollGrabY;
         ContentPanel() {
             backgroundColor(0xFF000000);
         }
@@ -269,6 +286,7 @@ public class SpacewarSelectionPanel extends UIPanel {
             layoutWidth = -1;
             layoutDirty = true;
             contentBuffer = null;
+            scrollDragging = false;
         }
 
         /** Sync selection, layout if needed, then paint the buffer. */
@@ -450,11 +468,96 @@ public class SpacewarSelectionPanel extends UIPanel {
             Shape save = g2.getClip();
             g2.clipRect(0, 0, width, height);
             g2.drawImage(contentBuffer, 0, 0, null);
+            drawScrollbar(g2);
             g2.setClip(save);
+        }
+
+        /** @return true if the list can scroll */
+        boolean scrollable() {
+            return maxOffset > 0;
+        }
+
+        /** Recompute track/thumb rectangles from {@link #offset} / {@link #maxOffset}. */
+        void updateScrollGeometry() {
+            if (!scrollable()) {
+                scrollTrack.setBounds(0, 0, 0, 0);
+                scrollThumb.setBounds(0, 0, 0, 0);
+                return;
+            }
+            // Full content height so top/bottom margins stay equal.
+            int x = width - SCROLL_BAR_WIDTH;
+            scrollTrack.setBounds(x, 0, SCROLL_BAR_WIDTH, height);
+
+            int thumbH = Math.max(SCROLL_MIN_THUMB, height / (maxOffset + 1));
+            if (thumbH > height) {
+                thumbH = height;
+            }
+            int travel = height - thumbH;
+            int thumbY = 0;
+            if (travel > 0 && maxOffset > 0) {
+                thumbY = (int)Math.round(1.0 * offset * travel / maxOffset);
+            }
+            scrollThumb.setBounds(x, thumbY, SCROLL_BAR_WIDTH, thumbH);
+        }
+
+        void drawScrollbar(Graphics2D g2) {
+            updateScrollGeometry();
+            if (!scrollable()) {
+                return;
+            }
+            g2.setColor(SCROLL_TRACK);
+            g2.fillRect(scrollTrack.x, scrollTrack.y, scrollTrack.width, scrollTrack.height);
+            g2.setColor(SCROLL_THUMB);
+            g2.fillRect(scrollThumb.x, scrollThumb.y, scrollThumb.width, scrollThumb.height);
+        }
+
+        /**
+         * Place the thumb so its top is {@code thumbTop} and sync {@link #offset}.
+         * @param thumbTop desired thumb top in content-local Y
+         */
+        void setOffsetFromThumbTop(int thumbTop) {
+            updateScrollGeometry();
+            int travel = scrollTrack.height - scrollThumb.height;
+            if (travel <= 0) {
+                offset = 0;
+            } else {
+                int ty = Math.max(scrollTrack.y, Math.min(thumbTop, scrollTrack.y + travel));
+                offset = (int)Math.round(1.0 * (ty - scrollTrack.y) * maxOffset / travel);
+            }
+            clampOffset();
+            updateScrollGeometry();
         }
 
         @Override
         public boolean mouse(UIMouse e) {
+            if (scrollDragging) {
+                if (e.has(Type.DRAG) || e.has(Type.MOVE)) {
+                    setOffsetFromThumbTop(e.y - scrollGrabY);
+                    return true;
+                }
+                if (e.has(Type.UP) || e.has(Type.LEAVE)) {
+                    scrollDragging = false;
+                    return true;
+                }
+            }
+            if (scrollable() && e.has(Type.DOWN) && e.has(Button.LEFT)) {
+                updateScrollGeometry();
+                if (scrollThumb.contains(e.x, e.y)) {
+                    scrollDragging = true;
+                    scrollGrabY = e.y - scrollThumb.y;
+                    return true;
+                }
+                if (scrollTrack.contains(e.x, e.y)) {
+                    setOffsetFromThumbTop(e.y - scrollThumb.height / 2);
+                    scrollDragging = true;
+                    scrollGrabY = scrollThumb.height / 2;
+                    return true;
+                }
+            }
+            if (e.has(Type.UP) || e.has(Type.LEAVE)) {
+                scrollDragging = false;
+            }
+
             // Coordinates are content-local; convert to panel-local for bounds.
             int mx = e.x;
             int my = e.y + CONTENT_TOP;

--- a/src/hu/openig/screen/panels/SpacewarSelectionPanel.java
+++ b/src/hu/openig/screen/panels/SpacewarSelectionPanel.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 /**
  * Spacewar middle status panel: group buttons + scrollable selection grid.
@@ -255,7 +256,6 @@ public class SpacewarSelectionPanel extends UIPanel {
             selectionScratch.clear();
             for (SpacewarSelectionCell c : cells) {
                 c.structure = null;
-                c.visibleInViewport = false;
                 cellPool.add(c);
             }
             cells.clear();
@@ -304,7 +304,6 @@ public class SpacewarSelectionPanel extends UIPanel {
         void rebuildCells() {
             for (SpacewarSelectionCell c : cells) {
                 c.structure = null;
-                c.visibleInViewport = false;
                 cellPool.add(c);
             }
             cells.clear();
@@ -324,14 +323,13 @@ public class SpacewarSelectionPanel extends UIPanel {
         void syncFromSelection() {
             collectSelection();
             if (!selectionMatchesCells()) {
-                offset = 0;
                 rebuildCells();
             } else {
-                for (SpacewarSelectionCell c : cells) {
+                forEachVisibleCell((c, y0) -> {
                     if (c.syncLoadout()) {
                         layoutDirty = true;
                     }
-                }
+                });
             }
             if (layoutWidth != width) {
                 layoutDirty = true;
@@ -354,7 +352,6 @@ public class SpacewarSelectionPanel extends UIPanel {
             SelectionRow current = null;
             int x0 = 0;
             for (SpacewarSelectionCell c : cells) {
-                c.visibleInViewport = false;
                 if (current != null && x0 > 0 && x0 + c.cellWidth >= innerWidth) {
                     rows.add(current);
                     current = null;
@@ -396,6 +393,22 @@ public class SpacewarSelectionPanel extends UIPanel {
             }
         }
 
+        /**
+         * Invoke {@code action} for each cell on the visible page.
+         * @param action receives the cell and its content-local top Y
+         */
+        void forEachVisibleCell(BiConsumer<SpacewarSelectionCell, Integer> action) {
+            int y0 = CONTENT_PAD_Y;
+            int viewBottom = height - CONTENT_PAD_Y;
+            for (int r = offset; r < rows.size() && y0 < viewBottom; r++) {
+                SelectionRow row = rows.get(r);
+                for (SpacewarSelectionCell c : row.cells) {
+                    action.accept(c, y0);
+                }
+                y0 += row.height + CELL_GAP;
+            }
+        }
+
         int ensureContentBuffer() {
             int bw = Math.max(1, width);
             int bh = Math.max(1, height);
@@ -419,27 +432,13 @@ public class SpacewarSelectionPanel extends UIPanel {
                 bg.setColor(Color.BLACK);
                 bg.fillRect(0, 0, contentBuffer.getWidth(), viewH);
 
-                for (SpacewarSelectionCell c : cells) {
-                    c.visibleInViewport = false;
-                }
-
-                int y0 = CONTENT_PAD_Y;
-                int viewBottom = viewH - CONTENT_PAD_Y;
-                for (int r = offset; r < rows.size(); r++) {
-                    SelectionRow row = rows.get(r);
-                    if (y0 >= viewBottom) {
-                        break;
-                    }
-                    for (SpacewarSelectionCell c : row.cells) {
-                        c.refreshCombatStats();
-                        c.rebuildDefenseSegments();
-                        c.visibleInViewport = true;
-                        // Bounds in parent (SpacewarSelectionPanel) coordinates.
-                        c.bounds.setBounds(c.rowX, CONTENT_TOP + y0, c.cellWidth, c.cellHeight);
-                        c.paint(bg, c.rowX, y0);
-                    }
-                    y0 += row.height + CELL_GAP;
-                }
+                forEachVisibleCell((c, y0) -> {
+                    c.refreshCombatStats();
+                    c.rebuildDefenseSegments();
+                    // Bounds in parent (SpacewarSelectionPanel) coordinates.
+                    c.bounds.setBounds(c.rowX, CONTENT_TOP + y0, c.cellWidth, c.cellHeight);
+                    c.paint(bg, c.rowX, y0);
+                });
             } finally {
                 bg.dispose();
             }
@@ -485,12 +484,13 @@ public class SpacewarSelectionPanel extends UIPanel {
         }
 
         SpacewarSelectionCell cellAt(int mx, int my) {
-            for (SpacewarSelectionCell c : cells) {
-                if (c.visibleInViewport && c.bounds.contains(mx, my)) {
-                    return c;
+            SpacewarSelectionCell[] hit = { null };
+            forEachVisibleCell((c, y0) -> {
+                if (hit[0] == null && c.bounds.contains(mx, my)) {
+                    hit[0] = c;
                 }
-            }
-            return null;
+            });
+            return hit[0];
         }
 
         void addTypeToSelection(int mx, int my, boolean category) {


### PR DESCRIPTION
## Summary
- Sync/paint/hit-test only visible selection cells via `forEachVisibleCell` (drops per-frame O(n) `visibleInViewport` bookkeeping).
- Keep scroll position when the selection shrinks (e.g. a ship dies) instead of resetting to the top.
- Add a draggable right-edge scrollbar overlay when the list overflows.

Follow-up to #1272 / #1221.

## Tested
- Large selection: FPS stays fine with panel fully visible
- Scroll with wheel and by dragging the scrollbar thumb; click track to jump
- Scroll near the bottom, let a selected ship die - list should not jump to the top
- Right-click remove / double-click type filters still work with the scrollbar present

<img width="1619" height="1008" alt="Screenshot 2026-07-30 at 15 10 14" src="https://github.com/user-attachments/assets/88258374-9794-46bf-aa61-98f11e0bc21e" />
