### PR TITLE
Supersample UI scale when vector fonts are on.

### DIFF
--- a/src/hu/openig/GameWindow.java
+++ b/src/hu/openig/GameWindow.java
@@ -141,9 +141,10 @@ public class GameWindow extends JFrame implements GameControls {
         /** Save transform before draw. */
         AffineTransform predraw;
         /**
-         * Logical-resolution back-buffer used when {@code uiScale != 100}.
-         * Screens draw 1:1 into this image; one scaled blit goes to the window.
-         * Avoids per-{@code drawImage} AffineTransform filtering (huge FPS drop).
+         * UI-scale back-buffer when {@code uiScale != 100}.
+         * Bitmap fonts: logical size, one bilinear blit (fast path from #1264).
+         * Vector fonts: physical size ({@code logical × uiScale/100}); screens paint
+         * under {@code g.scale} so text rasterizes at device pixels, then a 1:1 blit.
          */
         BufferedImage scaleBuffer;
         /** When did the last paint happen. */
@@ -181,10 +182,10 @@ public class GameWindow extends JFrame implements GameControls {
             }
         }
         /**
-         * Ensure the UI-scale back-buffer matches the logical inner size.
+         * Ensure the UI-scale back-buffer matches the required size.
          * @param g2 window graphics (for a compatible image config)
-         * @param iw logical width
-         * @param ih logical height
+         * @param iw buffer width
+         * @param ih buffer height
          * @return {@code true} if a new buffer was allocated (contents are empty / black)
          */
         boolean ensureScaleBuffer(Graphics2D g2, int iw, int ih) {
@@ -337,34 +338,55 @@ public class GameWindow extends JFrame implements GameControls {
             Graphics2D g2 = (Graphics2D)g;
             try {
                 if (uis != 100) {
-                    // Render at logical size, then scale once. Live g2.scale() on the
-                    // window Graphics makes every drawImage (tiles, UI, text) go through
-                    // AffineTransform filtering — especially brutal with bilinear on PlanetScreen.
+                    // Bitmap fonts: logical buffer + one blit (#1264) — fast, soft upsample OK.
+                    // Vector fonts: supersampled buffer (physical size, paint under scale) so
+                    // glyphs rasterize at device pixels; nearest on drawImage avoids bilinear
+                    // tile filtering while scaled. Expect FPS closer to pre-#1264 on maps.
                     int iw = getInnerWidth();
                     int ih = getInnerHeight();
-                    if (ensureScaleBuffer(g2, iw, ih)) {
-                        // New buffer has no prior primary/secondary pixels — must full-paint.
-                        r0 = true;
-                    }
-                    Graphics2D bg = scaleBuffer.createGraphics();
-                    try {
-                        clipScaleBufferToWindowDirtyRegion(g2, bg, uis, iw, ih);
-                        paintScreens(bg, r0, r1);
-                    } finally {
-                        bg.dispose();
-                    }
-
-                    AffineTransform at0 = g2.getTransform();
-                    Object prevHint = g2.getRenderingHint(RenderingHints.KEY_INTERPOLATION);
-                    try {
-                        g2.scale(uis / 100d, uis / 100d);
-                        g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
-                                RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+                    boolean shouldSupersample = commons.text().isUseStandardFonts();
+                    if (shouldSupersample) {
+                        int pw = Math.max(1, (int)Math.ceil(iw * uis / 100d));
+                        int ph = Math.max(1, (int)Math.ceil(ih * uis / 100d));
+                        if (ensureScaleBuffer(g2, pw, ph)) {
+                            r0 = true;
+                        }
+                        Graphics2D bg = scaleBuffer.createGraphics();
+                        try {
+                            bg.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                                    RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
+                            bg.scale(uis / 100d, uis / 100d);
+                            clipScaleBufferToWindowDirtyRegion(g2, bg, uis, iw, ih);
+                            paintScreens(bg, r0, r1);
+                        } finally {
+                            bg.dispose();
+                        }
                         g2.drawImage(scaleBuffer, 0, 0, null);
-                    } finally {
-                        g2.setTransform(at0);
-                        if (prevHint != null) {
-                            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, prevHint);
+                    } else {
+                        if (ensureScaleBuffer(g2, iw, ih)) {
+                            // New buffer has no prior primary/secondary pixels — must full-paint.
+                            r0 = true;
+                        }
+                        Graphics2D bg = scaleBuffer.createGraphics();
+                        try {
+                            clipScaleBufferToWindowDirtyRegion(g2, bg, uis, iw, ih);
+                            paintScreens(bg, r0, r1);
+                        } finally {
+                            bg.dispose();
+                        }
+
+                        AffineTransform at0 = g2.getTransform();
+                        Object prevHint = g2.getRenderingHint(RenderingHints.KEY_INTERPOLATION);
+                        try {
+                            g2.scale(uis / 100d, uis / 100d);
+                            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION,
+                                    RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+                            g2.drawImage(scaleBuffer, 0, 0, null);
+                        } finally {
+                            g2.setTransform(at0);
+                            if (prevHint != null) {
+                                g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, prevHint);
+                            }
                         }
                     }
                 } else {
@@ -2194,7 +2216,9 @@ public class GameWindow extends JFrame implements GameControls {
 
             setSize(Math.min(mxs.width, Math.max(sw + dx, getWidth())), Math.min(mxs.height, Math.max(sh + dy, getHeight())));
 
-            commons.text().setFontScaling(config.uiScale / 100d);
+            // Keep vector-font metrics in logical pixels; UI scale is applied by the
+            // back-buffer path (blit or supersampled paint-under-scale).
+            commons.text().setFontScaling(1d);
         }
     }
     @Override
@@ -2317,7 +2341,7 @@ public class GameWindow extends JFrame implements GameControls {
 
                 int th = 10;
 
-                UIColorLabel lbl = new UIColorLabel(th * config.uiScale / 100, commons.text());
+                UIColorLabel lbl = new UIColorLabel(th, commons.text());
                 lbl.width = config.tooltipWidth;
                 lbl.text(tooltipText);
                 lbl.width = lbl.maxWidth();

--- a/src/hu/openig/render/TextRenderer.java
+++ b/src/hu/openig/render/TextRenderer.java
@@ -16,6 +16,7 @@ import java.awt.Color;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.font.FontRenderContext;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
@@ -205,7 +206,7 @@ public class TextRenderer {
      * @param textCacheSize the text rendering cache size or 0 to disable it
      */
     public TextRenderer(ResourceLocator rl, boolean useStandardFonts, int textCacheSize) {
-        frc = new FontRenderContext(null, false, true);
+        frc = new FontRenderContext(null, true, true);
         this.useStandardFonts = useStandardFonts;
 
         charImage = rl.getImage("charset");
@@ -223,15 +224,20 @@ public class TextRenderer {
     }
     /**
      * Set the font scaling on the font render context if using standard fonts.
+     * <p>Pass {@code 1} for identity. Do not pass the UI scale here: interface
+     * magnification is applied by GameWindow's back-buffer. Scaling the FRC as
+     * well only widens {@link #getTextWidth} while {@link #paintTo} still draws
+     * unscaled glyphs, which distorts layout.
      * @param scale the scaling to use, use 1 to reset the scaling
      */
     public void setFontScaling(double scale) {
         if (scale <= 1) {
-            frc = new FontRenderContext(null, false, true);
+            frc = new FontRenderContext(null, true, true);
+            return;
         }
         AffineTransform tx = new AffineTransform();
         tx.scale(scale, scale);
-        frc = new FontRenderContext(tx, false, true);
+        frc = new FontRenderContext(tx, true, true);
     }
     /**
      * A line definition.
@@ -389,15 +395,25 @@ public class TextRenderer {
         if (useStandardFonts) {
             Font f = g.getFont();
             Color c = g.getColor();
-            g.setFont(standardFont(size));
-            g.setColor(new Color(color));
-            FontMetrics fm = g.getFontMetrics();
-            g.drawString(text, x, y + fm.getAscent() - fm.getDescent() / 2 /* - 4 */);
-//            g.drawLine(x, y, x + 5, y);
-//            g.drawLine(x, y + size - 1, x + 5, y + size - 1);
-//            g.drawLine(x, y + fm.getAscent() + fm.getDescent() - 1, x + 5, y + fm.getAscent() + fm.getDescent() - 1);
-            g.setColor(c);
-            g.setFont(f);
+            Object prevAA = g.getRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING);
+            Object prevFM = g.getRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS);
+            try {
+                g.setFont(standardFont(size));
+                g.setColor(new Color(color));
+                g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                        RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+                g.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS,
+                        RenderingHints.VALUE_FRACTIONALMETRICS_ON);
+                FontMetrics fm = g.getFontMetrics();
+                g.drawString(text, x, y + fm.getAscent() - fm.getDescent() / 2 /* - 4 */);
+            } finally {
+                g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                        prevAA != null ? prevAA : RenderingHints.VALUE_TEXT_ANTIALIAS_DEFAULT);
+                g.setRenderingHint(RenderingHints.KEY_FRACTIONALMETRICS,
+                        prevFM != null ? prevFM : RenderingHints.VALUE_FRACTIONALMETRICS_DEFAULT);
+                g.setColor(c);
+                g.setFont(f);
+            }
             return;
         }
         if (useTextCache) {

--- a/src/hu/openig/screen/CommonResources.java
+++ b/src/hu/openig/screen/CommonResources.java
@@ -368,7 +368,10 @@ public class CommonResources implements GameEnvironment {
 
             traits.load(rl.getXML("traits"));
 
-            text.setFontScaling(config.uiScale / 100d);
+            // UI scale is applied by GameWindow's back-buffer (blit or supersample).
+            // Scaling the FRC only affects vector-font getTextWidth and desyncs it from
+            // paintTo, which distorts layout whenever useStandardFonts is on.
+            text.setFontScaling(1d);
 
             // FIXME during translation
 

--- a/src/hu/openig/screen/panels/SpacewarSelectionPanel.java
+++ b/src/hu/openig/screen/panels/SpacewarSelectionPanel.java
@@ -25,7 +25,6 @@ import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.Shape;
-import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -228,7 +227,7 @@ public class SpacewarSelectionPanel extends UIPanel {
     }
 
     /**
-     * Scrollable viewport: owns cell pool, row layout, and atomic buffer paint.
+     * Scrollable viewport: owns cell pool, row layout, and visible-page paint.
      */
     final class ContentPanel extends UIPanel {
         /** Scroll offset in layout rows. */
@@ -239,8 +238,6 @@ public class SpacewarSelectionPanel extends UIPanel {
         int layoutWidth = -1;
         /** True when rows must be recomputed. */
         boolean layoutDirty = true;
-        /** Offscreen buffer for the visible page. */
-        BufferedImage contentBuffer;
         /** Scratch list of the current selection. */
         final List<SpacewarStructure> selectionScratch = new ArrayList<>();
         /** Bound cells in display order. */
@@ -285,14 +282,12 @@ public class SpacewarSelectionPanel extends UIPanel {
             maxOffset = 0;
             layoutWidth = -1;
             layoutDirty = true;
-            contentBuffer = null;
             scrollDragging = false;
         }
 
-        /** Sync selection, layout if needed, then paint the buffer. */
+        /** Sync selection and layout; hit-test bounds are refreshed in {@link #draw}. */
         void syncAndLayout() {
             syncFromSelection();
-            renderContentBuffer();
         }
 
         void collectSelection() {
@@ -427,47 +422,20 @@ public class SpacewarSelectionPanel extends UIPanel {
             }
         }
 
-        int ensureContentBuffer() {
-            int bw = Math.max(1, width);
-            int bh = Math.max(1, height);
-            if (contentBuffer == null
-                    || contentBuffer.getWidth() != bw
-                    || contentBuffer.getHeight() != bh) {
-                contentBuffer = new BufferedImage(bw, bh, BufferedImage.TYPE_INT_ARGB);
-            }
-            return bh;
-        }
-
-        /**
-         * Compose the visible page into {@link #contentBuffer}.
-         * Icons, bars and labels for every visible cell are painted here
-         * before a single blit in {@link #draw(Graphics2D)}.
-         */
-        void renderContentBuffer() {
-            int viewH = ensureContentBuffer();
-            Graphics2D bg = contentBuffer.createGraphics();
-            try {
-                bg.setColor(Color.BLACK);
-                bg.fillRect(0, 0, contentBuffer.getWidth(), viewH);
-
-                forEachVisibleCell((c, y0) -> {
-                    c.refreshCombatStats();
-                    c.rebuildDefenseSegments();
-                    // Bounds in parent (SpacewarSelectionPanel) coordinates.
-                    c.bounds.setBounds(c.rowX, CONTENT_TOP + y0, c.cellWidth, c.cellHeight);
-                    c.paint(bg, c.rowX, y0);
-                });
-            } finally {
-                bg.dispose();
-            }
-        }
-
         @Override
         public void draw(Graphics2D g2) {
-            // Buffer already prepared in syncAndLayout() during parent draw.
+            // Paint cells directly so vector text sees the supersampled transform
+            // instead of upscaling a pre-baked logical bitmap.
             Shape save = g2.getClip();
             g2.clipRect(0, 0, width, height);
-            g2.drawImage(contentBuffer, 0, 0, null);
+            g2.setColor(Color.BLACK);
+            g2.fillRect(0, 0, width, height);
+            forEachVisibleCell((c, y0) -> {
+                c.refreshCombatStats();
+                c.rebuildDefenseSegments();
+                c.bounds.setBounds(c.rowX, CONTENT_TOP + y0, c.cellWidth, c.cellHeight);
+                c.paint(g2, c.rowX, y0);
+            });
             drawScrollbar(g2);
             g2.setClip(save);
         }


### PR DESCRIPTION
## Summary
- With **vector / alternative fonts** and UI scale ≠ 100%, use a supersampled back-buffer (physical size, paint under `g.scale`, 1:1 blit) so glyphs rasterize at device pixels instead of being upscaled soft after [#1264](https://github.com/akarnokd/open-ig/pull/1264).
- **Bitmap fonts** keep the #1264 logical buffer + bilinear blit (fast path unchanged).
- Keep vector-font metrics in logical pixels (`setFontScaling(1)`), fix oversized tooltips, antialias vector `paintTo`, and paint the spacewar selection list live so a nested buffer doesn’t undo supersampling.

## Tested
- Bitmap fonts @ 100% / 200% — same look/FPS as master (#1264 path)
- Vector fonts @ 100% — unchanged
- Vector fonts @ 150% / 200% — text sharp (menus, spacewar ship list, status)
- Tooltips with UI scale > 100% — not oversized

| | |
|--|--|
| Master branch (post-#1264) @ 150% | <img width="2590" height="1668" alt="master-scale150" src="https://github.com/user-attachments/assets/f4d9a7d2-46b3-4eca-9286-e6aa15a70be7" /> |
| Master branch (post-#1264) @ 200% | <img width="2590" height="1668" alt="master-scale200" src="https://github.com/user-attachments/assets/c5902cac-2079-4e06-bbff-21f509b7fe8a" />|
| Fix @ 150% |  <img width="2590" height="1668" alt="supersample-150scale" src="https://github.com/user-attachments/assets/16111180-b1d5-4b63-831a-505b7a14e575" />|
| Fix @ 200% | <img width="2590" height="1668" alt="supersample-200scale" src="https://github.com/user-attachments/assets/72695af9-fde9-41dd-a6bb-434d0e3d1dfd" /> |

Fixes #1275